### PR TITLE
Fix Google 400 error for events with zero-minute reminders

### DIFF
--- a/caldir-provider-google/src/google_event/to_google.rs
+++ b/caldir-provider-google/src/google_event/to_google.rs
@@ -22,18 +22,20 @@ impl ToGoogle for Event {
             Transparency::Transparent => "transparent".to_string(),
         };
 
-        let reminders = if self.reminders.is_empty() {
+        let valid_reminders: Vec<_> = self
+            .reminders
+            .iter()
+            .filter(|r| r.minutes > 0)
+            .map(|r| google_calendar::types::EventReminder {
+                method: "popup".to_string(),
+                minutes: r.minutes,
+            })
+            .collect();
+        let reminders = if valid_reminders.is_empty() {
             None
         } else {
             Some(google_calendar::types::Reminders {
-                overrides: self
-                    .reminders
-                    .iter()
-                    .map(|r| google_calendar::types::EventReminder {
-                        method: "popup".to_string(),
-                        minutes: r.minutes,
-                    })
-                    .collect(),
+                overrides: valid_reminders,
                 use_default: false,
             })
         };


### PR DESCRIPTION
## Problem

Events with a `VALARM` trigger of `TRIGGER;RELATED=START:P0D` (fires at event start, i.e. 0 minutes before) cause a `400 Bad Request` from Google Calendar API:

```
Missing override reminder minutes.
```

**Root cause:** The `google-calendar` crate applies `#[serde(skip_serializing_if = "is_zero")]` to the `minutes` field of `EventReminder`. So when `minutes = 0`, the field is silently omitted from the serialized JSON. Google then rejects the reminder object because `minutes` is required.

<img width="1852" height="1188" alt="image" src="https://github.com/user-attachments/assets/3f21d5a8-4995-4df1-a8ae-dfc54a89bfc1" />


## Fix

Filter out reminders with `minutes <= 0` before building the Google event payload. These are reminders that fire at or after event start — Google's API requires a positive integer for reminder overrides, so there's no valid way to represent them. They're silently dropped rather than causing the push to fail.