### PR TITLE
Add copy button to install command

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -18,7 +18,22 @@ import TerminalDemo from "../components/TerminalDemo.astro";
     <p class="mb-4">Sync your Google Calendar or iCloud Calendar as a local directory of <code class="bg-code-bg px-1.5 py-0.5 rounded text-sm">.ics</code> files.<br />Store your events in a portable plaintext format that your LLM and unix tools understand.</p>
 
     <h2 class="text-sm text-muted/70 uppercase mb-2 mt-8">Quickstart</h2>
-    <div class="bg-terminal-bg text-terminal-text px-5 py-4 rounded-lg font-mono text-[0.95rem] max-md:text-[0.8rem] mb-4 overflow-x-auto whitespace-nowrap before:content-['$_'] before:text-terminal-muted before:select-none">curl -sSf https://caldir.org/install.sh | sh</div>
+    <div class="relative group mb-4">
+      <div class="bg-terminal-bg text-terminal-text px-5 py-4 rounded-lg font-mono text-[0.95rem] max-md:text-[0.8rem] overflow-x-auto whitespace-nowrap before:content-['$_'] before:text-terminal-muted before:select-none">curl -sSf https://caldir.org/install.sh | sh</div>
+      <button
+        id="copy-btn"
+        onclick="navigator.clipboard.writeText('curl -sSf https://caldir.org/install.sh | sh').then(() => { const icon = document.getElementById('copy-icon'); const check = document.getElementById('check-icon'); icon.classList.add('hidden'); check.classList.remove('hidden'); setTimeout(() => { icon.classList.remove('hidden'); check.classList.add('hidden'); }, 2000); })"
+        class="absolute right-3 top-1/2 -translate-y-1/2 p-1.5 rounded text-terminal-muted hover:text-terminal-text transition-colors"
+        aria-label="Copy to clipboard"
+      >
+        <svg id="copy-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+        </svg>
+        <svg id="check-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden">
+          <polyline points="20 6 9 17 4 12"/>
+        </svg>
+      </button>
+    </div>
 
     <div class="mt-8 flex gap-6">
       <a class="text-link hover:underline" href="/docs/what-is-caldir">Docs</a>


### PR DESCRIPTION
## Summary
- Adds a clipboard copy icon to the install command snippet on the homepage
- Clicking it copies the `curl` command and briefly shows a checkmark confirmation

## Test plan
- [ ] Visit the homepage
- [ ] Click the copy icon next to the install command
- [ ] Verify the command is copied to clipboard
- [ ] Verify the icon switches to a checkmark and reverts after 2 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)