### PR TITLE
Desktop Notifications for reminders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "caldir-notify"
-version = "0.5.0"
+version = "0.1.0"
 dependencies = [
  "caldir-core",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +159,24 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
 ]
 
 [[package]]
@@ -115,6 +189,30 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -173,6 +271,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -235,6 +355,17 @@ dependencies = [
  "toml",
  "uuid",
  "which",
+]
+
+[[package]]
+name = "caldir-notify"
+version = "0.5.0"
+dependencies = [
+ "caldir-core",
+ "chrono",
+ "clap",
+ "dirs",
+ "notify-rust",
 ]
 
 [[package]]
@@ -342,7 +473,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -616,6 +747,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +833,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -849,6 +1017,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1031,6 +1212,18 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1220,7 +1413,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1560,6 +1753,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26053f9919b5b032f327ab94d830f2465c4c88138e9df23c8fcd305060a9b28b"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1775,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1647,6 +1861,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +1915,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1751,6 +2018,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,7 +2084,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1917,6 +2194,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,12 +2249,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2645,6 +2965,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,6 +3170,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml",
+ "thiserror 2.0.17",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2893,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
  "itoa",
@@ -2903,22 +3246,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3044,6 +3387,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3160,6 +3515,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicase"
@@ -3399,6 +3765,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,9 +3807,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3435,9 +3847,34 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -3445,7 +3882,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3454,7 +3900,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3490,7 +3936,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3515,7 +3961,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -3524,6 +3970,24 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3721,6 +4185,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3798,4 +4323,44 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["caldir-cli", "caldir-core", "caldir-provider-caldav", "caldir-provider-google", "caldir-provider-icloud", "caldir-provider-outlook"]
+members = ["caldir-cli", "caldir-core", "caldir-notify", "caldir-provider-caldav", "caldir-provider-google", "caldir-provider-icloud", "caldir-provider-outlook"]
 resolver = "3"
 
 [workspace.package]

--- a/caldir-cli/src/commands/new.rs
+++ b/caldir-cli/src/commands/new.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use caldir_core::caldir::Caldir;
 use caldir_core::calendar::Calendar;
-use caldir_core::event::{Event, EventTime};
+use caldir_core::event::{Event, EventTime, Reminder};
 use chrono::Duration;
 use dialoguer::{Input, Select};
 use owo_colors::OwoColorize;
@@ -13,6 +13,7 @@ pub fn run(
     duration: Option<String>,
     location: Option<String>,
     calendar_slug: Option<String>,
+    reminder_args: Vec<String>,
     calendars: Vec<Calendar>,
 ) -> Result<()> {
     let interactive = title.is_none() || start.is_none();
@@ -60,6 +61,12 @@ pub fn run(
         None
     };
 
+    // --- Reminders ---
+    let reminders: Vec<Reminder> = reminder_args
+        .iter()
+        .map(|r| parse_reminder(r))
+        .collect::<Result<_>>()?;
+
     // --- Calendar ---
     let calendar = resolve_calendar(calendar_slug, &calendars, interactive)?;
 
@@ -70,7 +77,7 @@ pub fn run(
         None,
         location,
         None,
-        Vec::new(),
+        reminders,
     );
 
     let path = calendar.create_event(&event)?;
@@ -289,6 +296,14 @@ fn default_end(start: &EventTime) -> EventTime {
             tzid: tzid.clone(),
         },
     }
+}
+
+/// Parse a reminder string like "10m", "1h", "2 days" into a Reminder.
+fn parse_reminder(input: &str) -> Result<Reminder> {
+    let dur = humantime::parse_duration(input)
+        .map_err(|_| anyhow::anyhow!("Could not parse reminder: \"{}\"", input))?;
+    let minutes = (dur.as_secs() / 60) as i64;
+    Ok(Reminder { minutes })
 }
 
 /// Resolve which calendar to use.

--- a/caldir-cli/src/main.rs
+++ b/caldir-cli/src/main.rs
@@ -144,6 +144,10 @@ enum Commands {
         /// Calendar slug (defaults to default_calendar from config)
         #[arg(short = 'C', long)]
         calendar: Option<String>,
+
+        /// Reminder(s) before the event (e.g. "10m", "1h", "2 days"). Can be repeated.
+        #[arg(short, long)]
+        reminder: Vec<String>,
     },
     #[command(about = "Discard unpushed local changes (restore to remote state)")]
     Discard {
@@ -283,10 +287,11 @@ async fn main() -> Result<()> {
             duration,
             location,
             calendar,
+            reminder,
         } => {
             require_calendars()?;
             let calendars = resolve_calendars(None)?;
-            commands::new::run(title, start, end, duration, location, calendar, calendars)
+            commands::new::run(title, start, end, duration, location, calendar, reminder, calendars)
         }
         Commands::Discard {
             calendar,

--- a/caldir-notify/CLAUDE.md
+++ b/caldir-notify/CLAUDE.md
@@ -1,0 +1,53 @@
+# caldir-notify
+
+Desktop notification service for caldir reminders. Scans the caldir directory for events with VALARM reminders and fires OS notifications when they come due.
+
+## Architecture
+
+**Periodic timer, not a daemon.** The `caldir-notify` binary runs once, checks for due reminders, fires notifications, and exits. It's designed to be invoked every 60 seconds by a system timer (systemd on Linux, launchd on macOS).
+
+### How reminder checking works (`check.rs`)
+
+1. Load `Caldir` to find `calendar_dir`
+2. Discover all calendars via `Caldir::calendars()`
+3. For each calendar, load events in a window from -1h to +24h (covers any reasonable reminder offset)
+4. For each event with reminders, compute trigger time: `event.start - reminder.minutes`
+5. If the trigger time falls within the **last 60 seconds**, fire a notification
+
+**No state file needed.** Since the timer runs every 60s, each reminder's trigger time lands in exactly one 60-second window. If a run is missed (e.g. laptop asleep), the reminder is silently skipped — no stale alerts.
+
+### Notification delivery (`notify.rs`)
+
+Uses `notify-rust` for cross-platform notifications (Linux D-Bus / macOS notification center).
+
+- **Title**: Event summary (e.g. "Meeting with Alice")
+- **Body**: Human-readable time (e.g. "In 30 minutes") + location if present
+- **App name**: "caldir"
+
+### Install/Uninstall (`install/`)
+
+`caldir-notify install` and `caldir-notify uninstall` manage system-level scheduling:
+
+- **Linux** (`install/systemd.rs`): Writes `~/.config/systemd/user/caldir-notify.{service,timer}` with a 60-second interval, enables via `systemctl --user`
+- **macOS** (`install/launchd.rs`): Writes `~/Library/LaunchAgents/com.caldir.notify.plist` with `StartInterval=60`, loads via `launchctl`
+
+Platform dispatch is compile-time via `#[cfg(target_os)]` in `install/mod.rs`.
+
+## Commands
+
+```bash
+# Check for due reminders and fire notifications (what the timer runs)
+caldir-notify
+
+# Install the system timer to run automatically every 60s
+caldir-notify install
+
+# Remove the system timer
+caldir-notify uninstall
+```
+
+## caldir-core types used
+
+- `caldir_core::caldir::Caldir` — discover calendars
+- `caldir_core::calendar::Calendar` — load events via `events_in_range()`
+- `caldir_core::event::{Event, Reminder, EventTime}` — event data and reminder minutes

--- a/caldir-notify/CLAUDE.md
+++ b/caldir-notify/CLAUDE.md
@@ -10,7 +10,7 @@ Desktop notification service for caldir reminders. Scans the caldir directory fo
 
 1. Load `Caldir` to find `calendar_dir`
 2. Discover all calendars via `Caldir::calendars()`
-3. For each calendar, load events in a window from -1h to +24h (covers any reasonable reminder offset)
+3. For each calendar, load events in a window from -1h to +7 days (covers reminders like "1 week before")
 4. For each event with reminders, compute trigger time: `event.start - reminder.minutes`
 5. If the trigger time falls within the **last 60 seconds**, fire a notification
 

--- a/caldir-notify/CLAUDE.md
+++ b/caldir-notify/CLAUDE.md
@@ -37,7 +37,7 @@ Platform dispatch is compile-time via `#[cfg(target_os)]` in `install/mod.rs`.
 
 ```bash
 # Check for due reminders and fire notifications (what the timer runs)
-caldir-notify
+caldir-notify check
 
 # Install the system timer to run automatically every 60s
 caldir-notify install

--- a/caldir-notify/Cargo.toml
+++ b/caldir-notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caldir-notify"
-version = "0.5.0"
+version = "0.1.0"
 edition = "2024"
 description = "Desktop notification service for caldir reminders"
 license.workspace = true

--- a/caldir-notify/Cargo.toml
+++ b/caldir-notify/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "caldir-notify"
+version = "0.5.0"
+edition = "2024"
+description = "Desktop notification service for caldir reminders"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[[bin]]
+name = "caldir-notify"
+path = "src/main.rs"
+
+[dependencies]
+caldir-core = { path = "../caldir-core", version = "0.5.0" }
+notify-rust = "4"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
+dirs = "6"

--- a/caldir-notify/README.md
+++ b/caldir-notify/README.md
@@ -1,0 +1,28 @@
+# caldir-notify
+
+Desktop notifications for your [caldir](https://caldir.org) reminders. When an event in your caldir directory has a reminder (`VALARM`), caldir-notify delivers a native OS notification when it comes due.
+
+## Install
+
+```bash
+cargo install caldir-notify
+```
+
+## Setup
+
+After installing, run:
+
+```bash
+caldir-notify install
+```
+
+This creates a lightweight check that runs every minute (systemd user timer on Linux, launchd agent on macOS).
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `caldir-notify check` | Checks for due reminders and fire notifications (run by
+systemd/launchd) |
+| `caldir-notify install` | Install the system timer to run automatically |
+| `caldir-notify uninstall` | Remove the system timer |

--- a/caldir-notify/src/check.rs
+++ b/caldir-notify/src/check.rs
@@ -1,0 +1,46 @@
+use chrono::{Duration, Utc};
+
+use caldir_core::caldir::Caldir;
+use caldir_core::event::Event;
+
+use crate::notify::send_notification;
+
+/// Scan all calendars for reminders due in the last 60 seconds and fire notifications.
+pub fn check_and_notify() -> Result<(), Box<dyn std::error::Error>> {
+    let caldir = Caldir::load()?;
+    let now = Utc::now();
+    let window_start = now - Duration::seconds(60);
+
+    // Look at events starting within the next 24 hours (covers any reasonable reminder offset)
+    let range_start = now - Duration::hours(1);
+    let range_end = now + Duration::hours(24);
+
+    for calendar in caldir.calendars() {
+        let events = match calendar.events_in_range(range_start, range_end) {
+            Ok(events) => events,
+            Err(_) => continue,
+        };
+
+        for event in &events {
+            for reminder in event.reminders.iter() {
+                if let Some(trigger_time) = compute_trigger_time(event, reminder.minutes)
+                    && trigger_time >= window_start
+                    && trigger_time <= now
+                {
+                    send_notification(event, reminder.minutes)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Compute when a reminder should fire: event start minus reminder minutes.
+fn compute_trigger_time(
+    event: &Event,
+    minutes_before: i64,
+) -> Option<chrono::DateTime<Utc>> {
+    let start_utc = event.start.to_utc()?;
+    Some(start_utc - Duration::minutes(minutes_before))
+}

--- a/caldir-notify/src/check.rs
+++ b/caldir-notify/src/check.rs
@@ -11,9 +11,9 @@ pub fn check_and_notify() -> Result<(), Box<dyn std::error::Error>> {
     let now = Utc::now();
     let window_start = now - Duration::seconds(60);
 
-    // Look at events starting within the next 24 hours (covers any reasonable reminder offset)
+    // Look at events starting within the next 7 days (covers reminders like "1 week before")
     let range_start = now - Duration::hours(1);
-    let range_end = now + Duration::hours(24);
+    let range_end = now + Duration::days(7);
 
     for calendar in caldir.calendars() {
         let events = match calendar.events_in_range(range_start, range_end) {

--- a/caldir-notify/src/install/launchd.rs
+++ b/caldir-notify/src/install/launchd.rs
@@ -1,0 +1,70 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+const LABEL: &str = "com.caldir.notify";
+
+fn binary_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path = std::env::current_exe()?;
+    Ok(path)
+}
+
+fn plist_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    Ok(home.join(format!("Library/LaunchAgents/{}.plist", LABEL)))
+}
+
+pub fn install() -> Result<(), Box<dyn std::error::Error>> {
+    let bin = binary_path()?;
+    let plist = plist_path()?;
+
+    let content = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{label}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{bin}</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>60</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/tmp/caldir-notify.err</string>
+</dict>
+</plist>
+"#,
+        label = LABEL,
+        bin = bin.display()
+    );
+
+    if let Some(parent) = plist.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&plist, content)?;
+
+    Command::new("launchctl")
+        .args(["load", &plist.to_string_lossy()])
+        .status()?;
+
+    println!("Installed and loaded {}", LABEL);
+    Ok(())
+}
+
+pub fn uninstall() -> Result<(), Box<dyn std::error::Error>> {
+    let plist = plist_path()?;
+
+    if plist.exists() {
+        let _ = Command::new("launchctl")
+            .args(["unload", &plist.to_string_lossy()])
+            .status();
+        fs::remove_file(&plist)?;
+    }
+
+    println!("Uninstalled {}", LABEL);
+    Ok(())
+}

--- a/caldir-notify/src/install/launchd.rs
+++ b/caldir-notify/src/install/launchd.rs
@@ -28,6 +28,7 @@ pub fn install() -> Result<(), Box<dyn std::error::Error>> {
     <key>ProgramArguments</key>
     <array>
         <string>{bin}</string>
+        <string>check</string>
     </array>
     <key>StartInterval</key>
     <integer>60</integer>

--- a/caldir-notify/src/install/mod.rs
+++ b/caldir-notify/src/install/mod.rs
@@ -1,0 +1,30 @@
+#[cfg(target_os = "linux")]
+mod systemd;
+#[cfg(target_os = "macos")]
+mod launchd;
+
+pub fn install() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_os = "linux")]
+    systemd::install()?;
+
+    #[cfg(target_os = "macos")]
+    launchd::install()?;
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    return Err("Unsupported platform. Only Linux (systemd) and macOS (launchd) are supported.".into());
+
+    Ok(())
+}
+
+pub fn uninstall() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_os = "linux")]
+    systemd::uninstall()?;
+
+    #[cfg(target_os = "macos")]
+    launchd::uninstall()?;
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    return Err("Unsupported platform. Only Linux (systemd) and macOS (launchd) are supported.".into());
+
+    Ok(())
+}

--- a/caldir-notify/src/install/systemd.rs
+++ b/caldir-notify/src/install/systemd.rs
@@ -31,7 +31,7 @@ pub fn install() -> Result<(), Box<dyn std::error::Error>> {
          \n\
          [Service]\n\
          Type=oneshot\n\
-         ExecStart={}\n",
+         ExecStart={} check\n",
         bin.display()
     );
 

--- a/caldir-notify/src/install/systemd.rs
+++ b/caldir-notify/src/install/systemd.rs
@@ -1,0 +1,86 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn binary_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path = std::env::current_exe()?;
+    Ok(path)
+}
+
+fn systemd_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    Ok(home.join(".config/systemd/user"))
+}
+
+fn service_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    Ok(systemd_dir()?.join("caldir-notify.service"))
+}
+
+fn timer_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    Ok(systemd_dir()?.join("caldir-notify.timer"))
+}
+
+pub fn install() -> Result<(), Box<dyn std::error::Error>> {
+    let bin = binary_path()?;
+    let dir = systemd_dir()?;
+    fs::create_dir_all(&dir)?;
+
+    let service = format!(
+        "[Unit]\n\
+         Description=caldir reminder notifications\n\
+         \n\
+         [Service]\n\
+         Type=oneshot\n\
+         ExecStart={}\n",
+        bin.display()
+    );
+
+    let timer = "\
+        [Unit]\n\
+        Description=Run caldir-notify every 60 seconds\n\
+        \n\
+        [Timer]\n\
+        OnBootSec=30\n\
+        OnUnitActiveSec=60\n\
+        AccuracySec=5s\n\
+        \n\
+        [Install]\n\
+        WantedBy=timers.target\n";
+
+    fs::write(service_path()?, service)?;
+    fs::write(timer_path()?, timer)?;
+
+    Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .status()?;
+
+    Command::new("systemctl")
+        .args(["--user", "enable", "--now", "caldir-notify.timer"])
+        .status()?;
+
+    println!("Installed and started caldir-notify.timer");
+    Ok(())
+}
+
+pub fn uninstall() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = Command::new("systemctl")
+        .args(["--user", "disable", "--now", "caldir-notify.timer"])
+        .status();
+
+    let service = service_path()?;
+    let timer = timer_path()?;
+
+    if service.exists() {
+        fs::remove_file(&service)?;
+    }
+    if timer.exists() {
+        fs::remove_file(&timer)?;
+    }
+
+    Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .status()?;
+
+    println!("Uninstalled caldir-notify.timer");
+    Ok(())
+}

--- a/caldir-notify/src/main.rs
+++ b/caldir-notify/src/main.rs
@@ -8,11 +8,13 @@ use clap::{Parser, Subcommand};
 #[command(name = "caldir-notify", about = "Desktop notifications for caldir reminders")]
 struct Cli {
     #[command(subcommand)]
-    command: Option<Command>,
+    command: Command,
 }
 
 #[derive(Subcommand)]
 enum Command {
+    /// Check for due reminders and fire notifications
+    Check,
     /// Install the system timer/agent to run automatically
     Install,
     /// Uninstall the system timer/agent
@@ -23,9 +25,9 @@ fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        None => check::check_and_notify(),
-        Some(Command::Install) => install::install(),
-        Some(Command::Uninstall) => install::uninstall(),
+        Command::Check => check::check_and_notify(),
+        Command::Install => install::install(),
+        Command::Uninstall => install::uninstall(),
     };
 
     if let Err(e) = result {

--- a/caldir-notify/src/main.rs
+++ b/caldir-notify/src/main.rs
@@ -1,0 +1,35 @@
+mod check;
+mod install;
+mod notify;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "caldir-notify", about = "Desktop notifications for caldir reminders")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Install the system timer/agent to run automatically
+    Install,
+    /// Uninstall the system timer/agent
+    Uninstall,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        None => check::check_and_notify(),
+        Some(Command::Install) => install::install(),
+        Some(Command::Uninstall) => install::uninstall(),
+    };
+
+    if let Err(e) = result {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/caldir-notify/src/notify.rs
+++ b/caldir-notify/src/notify.rs
@@ -2,7 +2,10 @@ use notify_rust::Notification;
 
 use caldir_core::event::Event;
 
-pub fn send_notification(event: &Event, minutes_before: i64) -> Result<(), Box<dyn std::error::Error>> {
+pub fn send_notification(
+    event: &Event,
+    minutes_before: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
     let body = format_body(event, minutes_before);
 
     let mut notification = Notification::new();
@@ -12,7 +15,7 @@ pub fn send_notification(event: &Event, minutes_before: i64) -> Result<(), Box<d
         .body(&body);
 
     #[cfg(target_os = "macos")]
-    notification.sound_name("Ping");
+    notification.sound_name("Basso");
 
     notification.show()?;
 

--- a/caldir-notify/src/notify.rs
+++ b/caldir-notify/src/notify.rs
@@ -1,0 +1,38 @@
+use notify_rust::Notification;
+
+use caldir_core::event::Event;
+
+pub fn send_notification(event: &Event, minutes_before: i64) -> Result<(), Box<dyn std::error::Error>> {
+    let body = format_body(event, minutes_before);
+
+    Notification::new()
+        .appname("caldir")
+        .summary(&event.summary)
+        .body(&body)
+        .show()?;
+
+    Ok(())
+}
+
+fn format_body(event: &Event, minutes_before: i64) -> String {
+    let time_str = if minutes_before == 0 {
+        "Now".to_string()
+    } else if minutes_before == 1 {
+        "In 1 minute".to_string()
+    } else if minutes_before < 60 {
+        format!("In {} minutes", minutes_before)
+    } else if minutes_before == 60 {
+        "In 1 hour".to_string()
+    } else if minutes_before % 60 == 0 {
+        format!("In {} hours", minutes_before / 60)
+    } else {
+        let hours = minutes_before / 60;
+        let mins = minutes_before % 60;
+        format!("In {}h {}m", hours, mins)
+    };
+
+    match &event.location {
+        Some(loc) if !loc.is_empty() => format!("{}\n{}", time_str, loc),
+        _ => time_str,
+    }
+}

--- a/caldir-notify/src/notify.rs
+++ b/caldir-notify/src/notify.rs
@@ -5,11 +5,16 @@ use caldir_core::event::Event;
 pub fn send_notification(event: &Event, minutes_before: i64) -> Result<(), Box<dyn std::error::Error>> {
     let body = format_body(event, minutes_before);
 
-    Notification::new()
+    let mut notification = Notification::new();
+    notification
         .appname("caldir")
         .summary(&event.summary)
-        .body(&body)
-        .show()?;
+        .body(&body);
+
+    #[cfg(target_os = "macos")]
+    notification.sound_name("Ping");
+
+    notification.show()?;
 
     Ok(())
 }

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ test-notification:
   #!/usr/bin/env bash
   in_5_mins=$(date -d '+5 minutes' +%H:%M)
   cargo run -p caldir-cli -- new "Test notification" --start "today ${in_5_mins}" --reminder 5m
-  cargo run -p caldir-notify
+  cargo run -p caldir-notify -- check
 
 # Create a test event set to 5 mins from now
 # with a 4m reminder (to see if systemd notification fires)

--- a/justfile
+++ b/justfile
@@ -2,45 +2,33 @@
 default:
   @just --list
 
-# Test app commands:
-
-cli +args:
-  cargo run -p caldir-cli -- {{ args }}
-
-auth +args:
-  @just cli auth {{ args }}
-
-pull:
-  @just cli pull
-
-status:
-  @just cli status
-
-push:
-  @just cli push
-
-new +args:
-  @just cli new {{ args }}
-
-# Dev tools:
-
+# Lint check
 check:
   cargo check --workspace && cargo clippy --workspace
 
+# Run tests
 test:
   cargo test
 
 # Install provider binary to PATH
-install-provider:
+install-providers:
   cargo install --path caldir-provider-caldav
   cargo install --path caldir-provider-google
   cargo install --path caldir-provider-icloud
   cargo install --path caldir-provider-outlook
 
-# Build and install everything
-install: install-provider
+# Build and install all binaries
+install: install-providers
   cargo install --path caldir-cli
 
 # Serve website locally
 serve:
   cd website && npm run dev
+
+# Create a test event with a 5m reminder and immediately check for notifications
+test-notification:
+  #!/usr/bin/env bash
+  in_5_mins=$(date -d '+5 minutes' +%H:%M)
+  cargo run -p caldir-cli -- new "Test notification" --start "today ${in_5_mins}" --reminder 5m
+  cargo run -p caldir-notify
+

--- a/justfile
+++ b/justfile
@@ -20,15 +20,23 @@ install-providers:
 # Build and install all binaries
 install: install-providers
   cargo install --path caldir-cli
+  cargo install --path caldir-notify
 
 # Serve website locally
 serve:
   cd website && npm run dev
 
-# Create a test event with a 5m reminder and immediately check for notifications
+# Create test event set to 5 mins from now
+# with a 5m reminder (and immediately check for notifications)
 test-notification:
   #!/usr/bin/env bash
   in_5_mins=$(date -d '+5 minutes' +%H:%M)
   cargo run -p caldir-cli -- new "Test notification" --start "today ${in_5_mins}" --reminder 5m
   cargo run -p caldir-notify
 
+# Create a test event set to 5 mins from now
+# with a 4m reminder (to see if systemd notification fires)
+test-notification-systemd:
+  #!/usr/bin/env bash
+  in_5_mins=$(date -d '+5 minutes' +%H:%M)
+  cargo run -p caldir-cli -- new "Test notification" --start "today ${in_5_mins}" --reminder 4m

--- a/justfile
+++ b/justfile
@@ -30,7 +30,11 @@ serve:
 # with a 5m reminder (and immediately check for notifications)
 test-notification:
   #!/usr/bin/env bash
-  in_5_mins=$(date -d '+5 minutes' +%H:%M)
+  if date -d '+5 minutes' +%H:%M &>/dev/null; then
+    in_5_mins=$(date -d '+5 minutes' +%H:%M)
+  else
+    in_5_mins=$(date -v+5M +%H:%M)
+  fi
   cargo run -p caldir-cli -- new "Test notification" --start "today ${in_5_mins}" --reminder 5m
   cargo run -p caldir-notify -- check
 
@@ -38,5 +42,9 @@ test-notification:
 # with a 4m reminder (to see if systemd notification fires)
 test-notification-systemd:
   #!/usr/bin/env bash
-  in_5_mins=$(date -d '+5 minutes' +%H:%M)
+  if date -d '+5 minutes' +%H:%M &>/dev/null; then
+    in_5_mins=$(date -d '+5 minutes' +%H:%M)
+  else
+    in_5_mins=$(date -v+5M +%H:%M)
+  fi
   cargo run -p caldir-cli -- new "Test notification" --start "today ${in_5_mins}" --reminder 4m


### PR DESCRIPTION
Linux:
<img width="1000" height="318" alt="image" src="https://github.com/user-attachments/assets/3eaaba73-f55c-48cc-bc0d-9ae29e53a390" />

macOS:
<img width="780" height="194" alt="CleanShot 2026-03-08 at 10 12 08@2x" src="https://github.com/user-attachments/assets/00703787-8e6a-4d4c-b1d7-d9a199437863" />


For caldir to be a proper calendar system, it needs to handle reminders for upcoming events and send desktop notifications.

`caldir-notify` adds a simple periodic timer to systemd on Linux, and launchd on macOS. Every minute, it runs once, checks for due reminders, fires notifications, and exits.

For now, I'm keeping it extremely simple and not adding any extra state. Since the timer runs every 60s, each reminder's trigger time lands in exactly one 60-second window. If a run is missed (e.g. laptop asleep), the reminder is silently skipped, so you don't get reminders for events that already happened while your computer was asleep.

