### PR TITLE
Only emit legacy macOS migration warning once per process

### DIFF
--- a/caldir-core/src/paths.rs
+++ b/caldir-core/src/paths.rs
@@ -41,6 +41,18 @@ fn platform_config_dir() -> CalDirResult<PathBuf> {
 
 #[cfg(target_os = "macos")]
 fn migrate_legacy_macos_path(new_path: &std::path::Path) -> CalDirResult<()> {
+    use std::sync::OnceLock;
+
+    static MIGRATION_RESULT: OnceLock<Result<(), String>> = OnceLock::new();
+
+    MIGRATION_RESULT
+        .get_or_init(|| migrate_legacy_macos_path_inner(new_path).map_err(|e| e.to_string()))
+        .clone()
+        .map_err(CalDirError::Config)
+}
+
+#[cfg(target_os = "macos")]
+fn migrate_legacy_macos_path_inner(new_path: &std::path::Path) -> CalDirResult<()> {
     let home = dirs::home_dir()
         .ok_or_else(|| CalDirError::Config("Could not determine home directory".into()))?;
     let old_path = home


### PR DESCRIPTION
## Summary

`caldir_config_dir()` is called many times during a single command (once per provider session, once per config load, etc.), so the legacy macOS path migration check ran on every call. When both `~/.config/caldir` and `~/Library/Application Support/caldir` exist, the "config exists at both ... and ..." warning flooded stderr — e.g. `caldir status` printed it ~14 times.

This caches the migration result in a `OnceLock` so the check (and any warning) runs exactly once per process.

## Before

```
$ caldir status
warning: caldir config exists at both /Users/larskarbo/.config/caldir and /Users/larskarbo/Library/Application Support/caldir. Using the new location; remove the old one manually when ready.
warning: caldir config exists at both ...
warning: caldir config exists at both ...
... (repeated many times)
```

## After

The warning is emitted once, then suppressed for the remainder of the process.

## Test plan

- [ ] `cargo build` succeeds
- [ ] `cargo fmt --all -- --check` passes
- [ ] On a Mac with both legacy and new config dirs present, `caldir status` prints the warning exactly once
- [ ] On a Mac with only the new config dir, no warning is printed
- [ ] On a Mac with only the legacy config dir, the migration runs once and prints the "Migrating ..." message once

🤖 Generated with [Claude Code](https://claude.com/claude-code)