### PR TITLE
Fix RRULE parsing for Outlook published calendars

### DIFF
--- a/caldir-core/src/ics/mod.rs
+++ b/caldir-core/src/ics/mod.rs
@@ -4,6 +4,7 @@
 
 mod generate;
 mod parse;
+mod windows_tz;
 
 pub use generate::generate_ics;
 pub use parse::{parse_event, parse_events};

--- a/caldir-core/src/ics/parse.rs
+++ b/caldir-core/src/ics/parse.rs
@@ -6,6 +6,7 @@ use crate::{
         Reminders, Transparency,
     },
     event_time::EventTime,
+    ics::windows_tz,
 };
 use icalendar::{
     DatePerhapsTime,
@@ -152,7 +153,7 @@ fn to_event_time(dpt: DatePerhapsTime) -> EventTime {
             icalendar::CalendarDateTime::WithTimezone { date_time, tzid } => {
                 EventTime::DateTimeZoned {
                     datetime: date_time,
-                    tzid,
+                    tzid: windows_tz::normalize(tzid),
                 }
             }
         },
@@ -172,7 +173,8 @@ fn parse_exdate_property(prop: &Property) -> Vec<EventTime> {
         .params
         .iter()
         .find(|p| p.key == "TZID")
-        .and_then(|p| p.val.as_ref().map(|v| v.to_string()));
+        .and_then(|p| p.val.as_ref().map(|v| v.to_string()))
+        .map(windows_tz::normalize);
 
     let is_date = prop
         .params
@@ -512,5 +514,85 @@ END:VCALENDAR"#;
             "Should have second EXDATE date. Got: {:?}",
             dates
         );
+    }
+
+    #[test]
+    fn test_dtstart_windows_tzid_normalized_to_iana() {
+        // Outlook published-calendar feeds emit Microsoft Windows zone names.
+        // We normalize them at parse time so downstream consumers (rrule,
+        // chrono-tz) see only IANA names.
+        let ics = r#"BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:TEST
+BEGIN:VEVENT
+UID:outlook-event
+SUMMARY:Outlook Recurring Event
+DTSTART;TZID=E. South America Standard Time:20250320T090000
+DTEND;TZID=E. South America Standard Time:20250320T100000
+RRULE:FREQ=WEEKLY;BYDAY=MO
+END:VEVENT
+END:VCALENDAR"#;
+
+        let event = parse_event(ics).expect("Should parse");
+        match &event.start {
+            EventTime::DateTimeZoned { tzid, .. } => {
+                assert_eq!(tzid, "America/Sao_Paulo");
+            }
+            other => panic!("Expected DateTimeZoned, got {:?}", other),
+        }
+        match &event.end {
+            EventTime::DateTimeZoned { tzid, .. } => {
+                assert_eq!(tzid, "America/Sao_Paulo");
+            }
+            other => panic!("Expected DateTimeZoned, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_exdate_windows_tzid_normalized_to_iana() {
+        let ics = r#"BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:TEST
+BEGIN:VEVENT
+UID:outlook-event
+SUMMARY:Outlook Recurring Event
+DTSTART;TZID=W. Europe Standard Time:20250101T100000
+DTEND;TZID=W. Europe Standard Time:20250101T110000
+RRULE:FREQ=WEEKLY;BYDAY=MO
+EXDATE;TZID=W. Europe Standard Time:20250108T100000
+END:VEVENT
+END:VCALENDAR"#;
+
+        let event = parse_event(ics).expect("Should parse");
+        let recurrence = event.recurrence.expect("Should have recurrence");
+        assert_eq!(recurrence.exdates.len(), 1);
+        match &recurrence.exdates[0] {
+            EventTime::DateTimeZoned { tzid, .. } => {
+                assert_eq!(tzid, "Europe/Berlin");
+            }
+            other => panic!("Expected DateTimeZoned, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_iana_tzid_passes_through_unchanged() {
+        let ics = r#"BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:TEST
+BEGIN:VEVENT
+UID:test-event
+SUMMARY:Event
+DTSTART;TZID=America/New_York:20250320T090000
+DTEND;TZID=America/New_York:20250320T100000
+END:VEVENT
+END:VCALENDAR"#;
+
+        let event = parse_event(ics).expect("Should parse");
+        match &event.start {
+            EventTime::DateTimeZoned { tzid, .. } => {
+                assert_eq!(tzid, "America/New_York");
+            }
+            other => panic!("Expected DateTimeZoned, got {:?}", other),
+        }
     }
 }

--- a/caldir-core/src/ics/windows_tz.rs
+++ b/caldir-core/src/ics/windows_tz.rs
@@ -174,9 +174,15 @@ mod tests {
 
     #[test]
     fn maps_known_windows_zones() {
-        assert_eq!(to_iana("E. South America Standard Time"), Some("America/Sao_Paulo"));
+        assert_eq!(
+            to_iana("E. South America Standard Time"),
+            Some("America/Sao_Paulo")
+        );
         assert_eq!(to_iana("W. Europe Standard Time"), Some("Europe/Berlin"));
-        assert_eq!(to_iana("Pacific Standard Time"), Some("America/Los_Angeles"));
+        assert_eq!(
+            to_iana("Pacific Standard Time"),
+            Some("America/Los_Angeles")
+        );
     }
 
     #[test]

--- a/caldir-core/src/ics/windows_tz.rs
+++ b/caldir-core/src/ics/windows_tz.rs
@@ -1,0 +1,203 @@
+//! Map Microsoft Windows time zone names to IANA names.
+//!
+//! Outlook and other Microsoft tooling emit ICS with TZID values like
+//! `E. South America Standard Time` instead of `America/Sao_Paulo`. These
+//! names are valid in ICS (TZID is just an identifier per RFC 5545) but
+//! downstream consumers — like the `rrule` crate used for recurrence
+//! expansion — only accept IANA names.
+//!
+//! Source: Unicode CLDR `windowsZones.xml`, default territory ("001").
+
+/// Translate a Windows time zone name to its IANA equivalent.
+///
+/// Returns `None` if the input is already an IANA name or an unrecognized
+/// value — callers should treat that as "leave unchanged."
+pub(crate) fn to_iana(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "Dateline Standard Time" => "Etc/GMT+12",
+        "UTC-11" => "Etc/GMT+11",
+        "Aleutian Standard Time" => "America/Adak",
+        "Hawaiian Standard Time" => "Pacific/Honolulu",
+        "Marquesas Standard Time" => "Pacific/Marquesas",
+        "Alaskan Standard Time" => "America/Anchorage",
+        "UTC-09" => "Etc/GMT+9",
+        "Pacific Standard Time (Mexico)" => "America/Tijuana",
+        "UTC-08" => "Etc/GMT+8",
+        "Pacific Standard Time" => "America/Los_Angeles",
+        "US Mountain Standard Time" => "America/Phoenix",
+        "Mountain Standard Time (Mexico)" => "America/Mazatlan",
+        "Mountain Standard Time" => "America/Denver",
+        "Yukon Standard Time" => "America/Whitehorse",
+        "Central America Standard Time" => "America/Guatemala",
+        "Central Standard Time" => "America/Chicago",
+        "Easter Island Standard Time" => "Pacific/Easter",
+        "Central Standard Time (Mexico)" => "America/Mexico_City",
+        "Canada Central Standard Time" => "America/Regina",
+        "SA Pacific Standard Time" => "America/Bogota",
+        "Eastern Standard Time (Mexico)" => "America/Cancun",
+        "Eastern Standard Time" => "America/New_York",
+        "Haiti Standard Time" => "America/Port-au-Prince",
+        "Cuba Standard Time" => "America/Havana",
+        "US Eastern Standard Time" => "America/Indianapolis",
+        "Turks And Caicos Standard Time" => "America/Grand_Turk",
+        "Paraguay Standard Time" => "America/Asuncion",
+        "Atlantic Standard Time" => "America/Halifax",
+        "Venezuela Standard Time" => "America/Caracas",
+        "Central Brazilian Standard Time" => "America/Cuiaba",
+        "SA Western Standard Time" => "America/La_Paz",
+        "Pacific SA Standard Time" => "America/Santiago",
+        "Newfoundland Standard Time" => "America/St_Johns",
+        "Tocantins Standard Time" => "America/Araguaina",
+        "E. South America Standard Time" => "America/Sao_Paulo",
+        "SA Eastern Standard Time" => "America/Cayenne",
+        "Argentina Standard Time" => "America/Buenos_Aires",
+        "Greenland Standard Time" => "America/Godthab",
+        "Montevideo Standard Time" => "America/Montevideo",
+        "Magallanes Standard Time" => "America/Punta_Arenas",
+        "Saint Pierre Standard Time" => "America/Miquelon",
+        "Bahia Standard Time" => "America/Bahia",
+        "UTC-02" => "Etc/GMT+2",
+        "Mid-Atlantic Standard Time" => "Atlantic/South_Georgia",
+        "Azores Standard Time" => "Atlantic/Azores",
+        "Cape Verde Standard Time" => "Atlantic/Cape_Verde",
+        "UTC" => "Etc/UTC",
+        "GMT Standard Time" => "Europe/London",
+        "Greenwich Standard Time" => "Atlantic/Reykjavik",
+        "Sao Tome Standard Time" => "Africa/Sao_Tome",
+        "Morocco Standard Time" => "Africa/Casablanca",
+        "W. Europe Standard Time" => "Europe/Berlin",
+        "Central Europe Standard Time" => "Europe/Budapest",
+        "Romance Standard Time" => "Europe/Paris",
+        "Central European Standard Time" => "Europe/Warsaw",
+        "W. Central Africa Standard Time" => "Africa/Lagos",
+        "Jordan Standard Time" => "Asia/Amman",
+        "GTB Standard Time" => "Europe/Bucharest",
+        "Middle East Standard Time" => "Asia/Beirut",
+        "Egypt Standard Time" => "Africa/Cairo",
+        "E. Europe Standard Time" => "Europe/Chisinau",
+        "Syria Standard Time" => "Asia/Damascus",
+        "West Bank Standard Time" => "Asia/Hebron",
+        "South Africa Standard Time" => "Africa/Johannesburg",
+        "FLE Standard Time" => "Europe/Kiev",
+        "Israel Standard Time" => "Asia/Jerusalem",
+        "South Sudan Standard Time" => "Africa/Juba",
+        "Kaliningrad Standard Time" => "Europe/Kaliningrad",
+        "Sudan Standard Time" => "Africa/Khartoum",
+        "Libya Standard Time" => "Africa/Tripoli",
+        "Namibia Standard Time" => "Africa/Windhoek",
+        "Arabic Standard Time" => "Asia/Baghdad",
+        "Turkey Standard Time" => "Europe/Istanbul",
+        "Arab Standard Time" => "Asia/Riyadh",
+        "Belarus Standard Time" => "Europe/Minsk",
+        "Russian Standard Time" => "Europe/Moscow",
+        "E. Africa Standard Time" => "Africa/Nairobi",
+        "Volgograd Standard Time" => "Europe/Volgograd",
+        "Iran Standard Time" => "Asia/Tehran",
+        "Arabian Standard Time" => "Asia/Dubai",
+        "Astrakhan Standard Time" => "Europe/Astrakhan",
+        "Azerbaijan Standard Time" => "Asia/Baku",
+        "Russia Time Zone 3" => "Europe/Samara",
+        "Mauritius Standard Time" => "Indian/Mauritius",
+        "Saratov Standard Time" => "Europe/Saratov",
+        "Georgian Standard Time" => "Asia/Tbilisi",
+        "Caucasus Standard Time" => "Asia/Yerevan",
+        "Afghanistan Standard Time" => "Asia/Kabul",
+        "West Asia Standard Time" => "Asia/Tashkent",
+        "Qyzylorda Standard Time" => "Asia/Qyzylorda",
+        "Ekaterinburg Standard Time" => "Asia/Yekaterinburg",
+        "Pakistan Standard Time" => "Asia/Karachi",
+        "India Standard Time" => "Asia/Calcutta",
+        "Sri Lanka Standard Time" => "Asia/Colombo",
+        "Nepal Standard Time" => "Asia/Katmandu",
+        "Central Asia Standard Time" => "Asia/Bishkek",
+        "Bangladesh Standard Time" => "Asia/Dhaka",
+        "Omsk Standard Time" => "Asia/Omsk",
+        "Myanmar Standard Time" => "Asia/Rangoon",
+        "SE Asia Standard Time" => "Asia/Bangkok",
+        "Altai Standard Time" => "Asia/Barnaul",
+        "W. Mongolia Standard Time" => "Asia/Hovd",
+        "North Asia Standard Time" => "Asia/Krasnoyarsk",
+        "N. Central Asia Standard Time" => "Asia/Novosibirsk",
+        "Tomsk Standard Time" => "Asia/Tomsk",
+        "China Standard Time" => "Asia/Shanghai",
+        "North Asia East Standard Time" => "Asia/Irkutsk",
+        "Singapore Standard Time" => "Asia/Singapore",
+        "W. Australia Standard Time" => "Australia/Perth",
+        "Taipei Standard Time" => "Asia/Taipei",
+        "Ulaanbaatar Standard Time" => "Asia/Ulaanbaatar",
+        "Aus Central W. Standard Time" => "Australia/Eucla",
+        "Transbaikal Standard Time" => "Asia/Chita",
+        "Tokyo Standard Time" => "Asia/Tokyo",
+        "North Korea Standard Time" => "Asia/Pyongyang",
+        "Korea Standard Time" => "Asia/Seoul",
+        "Yakutsk Standard Time" => "Asia/Yakutsk",
+        "Cen. Australia Standard Time" => "Australia/Adelaide",
+        "AUS Central Standard Time" => "Australia/Darwin",
+        "E. Australia Standard Time" => "Australia/Brisbane",
+        "AUS Eastern Standard Time" => "Australia/Sydney",
+        "West Pacific Standard Time" => "Pacific/Port_Moresby",
+        "Tasmania Standard Time" => "Australia/Hobart",
+        "Vladivostok Standard Time" => "Asia/Vladivostok",
+        "Lord Howe Standard Time" => "Australia/Lord_Howe",
+        "Bougainville Standard Time" => "Pacific/Bougainville",
+        "Russia Time Zone 10" => "Asia/Srednekolymsk",
+        "Magadan Standard Time" => "Asia/Magadan",
+        "Norfolk Standard Time" => "Pacific/Norfolk",
+        "Sakhalin Standard Time" => "Asia/Sakhalin",
+        "Central Pacific Standard Time" => "Pacific/Guadalcanal",
+        "Russia Time Zone 11" => "Asia/Kamchatka",
+        "New Zealand Standard Time" => "Pacific/Auckland",
+        "UTC+12" => "Etc/GMT-12",
+        "Fiji Standard Time" => "Pacific/Fiji",
+        "Kamchatka Standard Time" => "Asia/Kamchatka",
+        "Chatham Islands Standard Time" => "Pacific/Chatham",
+        "UTC+13" => "Etc/GMT-13",
+        "Tonga Standard Time" => "Pacific/Tongatapu",
+        "Samoa Standard Time" => "Pacific/Apia",
+        "Line Islands Standard Time" => "Pacific/Kiritimati",
+        _ => return None,
+    })
+}
+
+/// Take a TZID string and return the IANA equivalent if the input is a
+/// known Windows zone name; otherwise return the input unchanged.
+pub(crate) fn normalize(tzid: String) -> String {
+    match to_iana(&tzid) {
+        Some(iana) => iana.to_owned(),
+        None => tzid,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_known_windows_zones() {
+        assert_eq!(to_iana("E. South America Standard Time"), Some("America/Sao_Paulo"));
+        assert_eq!(to_iana("W. Europe Standard Time"), Some("Europe/Berlin"));
+        assert_eq!(to_iana("Pacific Standard Time"), Some("America/Los_Angeles"));
+    }
+
+    #[test]
+    fn returns_none_for_iana_names() {
+        assert_eq!(to_iana("America/Sao_Paulo"), None);
+        assert_eq!(to_iana("Europe/Berlin"), None);
+    }
+
+    #[test]
+    fn returns_none_for_unknown_names() {
+        assert_eq!(to_iana("Bogus/Zone"), None);
+        assert_eq!(to_iana(""), None);
+    }
+
+    #[test]
+    fn normalize_rewrites_known_and_passes_through_others() {
+        assert_eq!(
+            normalize("E. South America Standard Time".into()),
+            "America/Sao_Paulo"
+        );
+        assert_eq!(normalize("America/New_York".into()), "America/New_York");
+        assert_eq!(normalize("Bogus/Zone".into()), "Bogus/Zone");
+    }
+}

--- a/caldir-core/src/recurrence.rs
+++ b/caldir-core/src/recurrence.rs
@@ -366,6 +366,37 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
     }
 
+    /// Regression test for Outlook published-calendar feeds, which emit
+    /// Microsoft Windows zone names like "E. South America Standard Time"
+    /// instead of IANA names. Parsing should normalize the TZID, so the
+    /// rrule crate accepts the resulting DTSTART line.
+    #[test]
+    fn test_parsed_outlook_windows_tzid_expands_correctly() {
+        use crate::ics::parse_event;
+
+        let ics = r#"BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:TEST
+BEGIN:VEVENT
+UID:outlook-event
+SUMMARY:Outlook Recurring Event
+DTSTART;TZID=E. South America Standard Time:20250320T090000
+DTEND;TZID=E. South America Standard Time:20250320T100000
+RRULE:FREQ=WEEKLY;BYDAY=MO
+END:VEVENT
+END:VCALENDAR"#;
+
+        let event = parse_event(ics).expect("Should parse");
+        let recurrence = event.recurrence.as_ref().expect("Should have recurrence");
+        let rrule_str = build_rrule_string(&event.start, recurrence, rrule::Tz::LOCAL);
+        let result: Result<RRuleSet, _> = rrule_str.parse();
+        assert!(
+            result.is_ok(),
+            "Expected RRULE to parse after Windows->IANA normalization, got: {:?}",
+            result.err()
+        );
+    }
+
     /// Reproduce the all-day event case:
     /// DTSTART;VALUE=DATE:20080508
     /// RRULE:FREQ=YEARLY;UNTIL=20220507


### PR DESCRIPTION
## Summary

Fixes a crash in `caldir events` when rendering recurring events pulled from an Outlook "Publish calendar" feed.

## Problem

Outlook published-calendar ICS feeds emit Microsoft Windows time zone names (e.g. `E. South America Standard Time`, `W. Europe Standard Time`, `Pacific Standard Time`) in TZID parameters. These are valid per RFC 5545 — TZID is a free-form identifier — but the `rrule` crate used in `recurrence::expand_recurring_event` only accepts IANA names, so it errors out:

```
ICS parse error: Failed to parse RRULE for event '...':
  RRule parsing error: `E. South America Standard Time` is not a valid timezone.
```

### Repro

1. In Outlook on the web: **Settings → Calendar → Shared calendars → Publish a calendar** and publish a calendar containing at least one recurring event. Copy the `.ics` URL.
2. `caldir connect webcal` and paste the URL.
3. `caldir pull && caldir events` — crashes with the error above.

## Fix

`caldir-core/src/ics/windows_tz.rs` adds a `to_iana()` lookup populated from CLDR `windowsZones.xml` (default territory "001"), plus a `normalize()` helper. The parser calls it at the two TZID extraction points:

- `to_event_time()` for `DTSTART` / `DTEND` / `RECURRENCE-ID`
- `parse_exdate_property()` for `EXDATE` `TZID` parameters

Unknown TZIDs pass through unchanged (graceful degradation if Microsoft adds a new zone name).

The existing `caldir-provider-webcal` needs no changes — the fix is fully contained in caldir-core, so every provider that returns parsed `Event` values gets it for free.

## Round-tripping caveat

This is a one-way mapping (Windows → IANA). The reverse isn't unambiguous since multiple IANA zones often share one Windows zone. Today this is moot — webcal is read-only and the Graph-based Outlook provider uses its own field types — but if a write-capable Outlook provider is added later, it may need a separate IANA → Windows step before pushing events back.

## Tests

- 4 unit tests in `windows_tz.rs` covering known mappings, IANA pass-through, unknown pass-through, and the `normalize()` helper.
- 3 integration tests in `parse.rs` covering DTSTART, EXDATE, and IANA pass-through.
- 1 end-to-end regression test in `recurrence.rs` that goes parse → `expand_recurring_event` to prove the original crash is fixed.

## Test plan
- [ ] `cargo test -p caldir-core` — all tests pass (47 total, 8 new)
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Connect webcal to an Outlook published calendar and run `caldir pull && caldir events`