### PR TITLE
Add `rust-toolchain.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.97.0
-        with:
-          components: rustfmt
-
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -25,11 +20,6 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.97.0
-        with:
-          components: clippy
 
       - name: Install just
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.0
         with:
           components: rustfmt
 
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.0
         with:
           components: clippy
 

--- a/caldir-provider-google/src/commands/create_event.rs
+++ b/caldir-provider-google/src/commands/create_event.rs
@@ -82,7 +82,7 @@ pub async fn handle(cmd: CreateEvent) -> Result<Event> {
                 .with_context(|| {
                     format!(
                         "Failed to update recurring instance: {}",
-                        &google_event.summary
+                        google_event.summary
                     )
                 })?;
 
@@ -107,7 +107,7 @@ pub async fn handle(cmd: CreateEvent) -> Result<Event> {
             &google_event,
         )
         .await
-        .with_context(|| format!("Failed to create event: {}", &google_event.summary))?;
+        .with_context(|| format!("Failed to create event: {}", google_event.summary))?;
 
     let created_event = Event::from_google(response.body)?;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
To make sure everyone uses the same Rust version and sees the same clippy errors