### PR TITLE
Handle webcal feed with no LAST-MODIFIED flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "async-trait",
  "caldir-core",
  "chrono",
+ "httpdate",
  "icalendar",
  "reqwest",
  "serde",

--- a/caldir-provider-webcal/Cargo.toml
+++ b/caldir-provider-webcal/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
+httpdate = "1"
 icalendar = "0.17.10"
 toml = "1"
 url = "2"

--- a/caldir-provider-webcal/src/commands/connect.rs
+++ b/caldir-provider-webcal/src/commands/connect.rs
@@ -27,15 +27,15 @@ pub async fn handle(cmd: Connect) -> Result<ConnectResponse> {
         // Normalize webcal:// to https://
         let url = raw_url.replacen("webcal://", "https://", 1);
 
-        let body = http::fetch_feed(&url).await?;
+        let feed = http::fetch_feed(&url).await?;
 
-        if !body.contains("BEGIN:VCALENDAR") {
+        if !feed.body.contains("BEGIN:VCALENDAR") {
             anyhow::bail!(
                 "The URL does not appear to be a valid ICS calendar feed (no BEGIN:VCALENDAR found)"
             );
         }
 
-        let calendar_config = build_calendar_config(&body, &url)?;
+        let calendar_config = build_calendar_config(&feed.body, &url)?;
 
         return Ok(ConnectResponse::Done {
             account_identifier: None,

--- a/caldir-provider-webcal/src/commands/list_events.rs
+++ b/caldir-provider-webcal/src/commands/list_events.rs
@@ -11,9 +11,9 @@ use crate::remote_config::WebcalRemoteConfig;
 pub async fn handle(cmd: ListEvents) -> Result<Vec<Event>> {
     let config = WebcalRemoteConfig::try_from(&cmd.remote)?;
 
-    let body = http::fetch_feed(&config.webcal_url).await?;
+    let feed = http::fetch_feed(&config.webcal_url).await?;
 
-    let all_events: Vec<Event> = Event::from_ics_str(&body)
+    let all_events: Vec<Event> = Event::from_ics_str(&feed.body)
         .map_err(|e| anyhow::anyhow!("Failed to parse webcal feed: {e}"))?
         .into_iter()
         .filter_map(|result| match result {
@@ -22,6 +22,12 @@ pub async fn handle(cmd: ListEvents) -> Result<Vec<Event>> {
                 eprintln!("caldir-provider-webcal: skipping malformed event: {err}");
                 None
             }
+        })
+        .map(|mut event| {
+            if event.last_modified.is_none() {
+                event.last_modified = feed.last_modified;
+            }
+            event
         })
         .collect();
 
@@ -63,10 +69,25 @@ mod tests {
 
     /// Apply the in-process filter logic without doing the HTTP fetch.
     fn filter_events(body: &str, from: &str, to: &str) -> Vec<Event> {
+        filter_events_with_feed_last_modified(body, from, to, None)
+    }
+
+    fn filter_events_with_feed_last_modified(
+        body: &str,
+        from: &str,
+        to: &str,
+        feed_last_modified: Option<DateTime<Utc>>,
+    ) -> Vec<Event> {
         let all: Vec<Event> = Event::from_ics_str(body)
             .unwrap()
             .into_iter()
             .map(Result::unwrap)
+            .map(|mut event| {
+                if event.last_modified.is_none() {
+                    event.last_modified = feed_last_modified;
+                }
+                event
+            })
             .collect();
 
         let from_utc = DateTime::parse_from_rfc3339(from)
@@ -171,6 +192,60 @@ END:VEVENT
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].uid.as_str(), "weekly@caldir");
         assert!(events[0].recurrence.is_some());
+    }
+
+    #[test]
+    fn uses_feed_last_modified_when_event_has_none() {
+        let body = ics_with(
+            r"BEGIN:VEVENT
+UID:missing@caldir
+DTSTART:20260615T100000Z
+DTEND:20260615T110000Z
+SUMMARY:Missing
+END:VEVENT
+",
+        );
+        let feed_last_modified = DateTime::parse_from_rfc3339("2026-07-13T06:00:11Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let events = filter_events_with_feed_last_modified(
+            &body,
+            "2026-06-01T00:00:00+00:00",
+            "2026-06-30T23:59:59+00:00",
+            Some(feed_last_modified),
+        );
+
+        assert_eq!(events[0].last_modified, Some(feed_last_modified));
+    }
+
+    #[test]
+    fn keeps_event_last_modified_when_present() {
+        let body = ics_with(
+            r"BEGIN:VEVENT
+UID:present@caldir
+DTSTART:20260615T100000Z
+DTEND:20260615T110000Z
+LAST-MODIFIED:20260701T120000Z
+SUMMARY:Present
+END:VEVENT
+",
+        );
+        let feed_last_modified = DateTime::parse_from_rfc3339("2026-07-13T06:00:11Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event_last_modified = DateTime::parse_from_rfc3339("2026-07-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let events = filter_events_with_feed_last_modified(
+            &body,
+            "2026-06-01T00:00:00+00:00",
+            "2026-06-30T23:59:59+00:00",
+            Some(feed_last_modified),
+        );
+
+        assert_eq!(events[0].last_modified, Some(event_last_modified));
     }
 
     #[test]

--- a/caldir-provider-webcal/src/http.rs
+++ b/caldir-provider-webcal/src/http.rs
@@ -1,11 +1,18 @@
 //! Thin HTTP wrapper for fetching ICS feeds.
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use reqwest::header::LAST_MODIFIED;
 
 const USER_AGENT: &str = "caldir-provider-webcal";
 const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-pub async fn fetch_feed(url: &str) -> Result<String> {
+pub struct FeedResponse {
+    pub body: String,
+    pub last_modified: Option<DateTime<Utc>>,
+}
+
+pub async fn fetch_feed(url: &str) -> Result<FeedResponse> {
     let client = reqwest::Client::builder()
         .timeout(TIMEOUT)
         .user_agent(USER_AGENT)
@@ -22,8 +29,36 @@ pub async fn fetch_feed(url: &str) -> Result<String> {
         anyhow::bail!("Failed to fetch {url}: HTTP {}", response.status());
     }
 
-    response
+    let last_modified = response
+        .headers()
+        .get(LAST_MODIFIED)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_last_modified);
+
+    let body = response
         .text()
         .await
-        .with_context(|| format!("Failed to read response body from {url}"))
+        .with_context(|| format!("Failed to read response body from {url}"))?;
+
+    Ok(FeedResponse {
+        body,
+        last_modified,
+    })
+}
+
+fn parse_last_modified(value: &str) -> Option<DateTime<Utc>> {
+    httpdate::parse_http_date(value)
+        .ok()
+        .map(DateTime::<Utc>::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_http_last_modified() {
+        let parsed = parse_last_modified("Mon, 13 Jul 2026 06:00:11 GMT").unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-07-13T06:00:11+00:00");
+    }
 }


### PR DESCRIPTION
I noticed that some public webcal feeds (like this [FIFA World Cup one](https://matchcalendar.football/ics/wc2026.ics)) don't have a `LAST-MODIFIED` field on their events, which caused the feed to not detect updates.

This adds a fallback to the webcal provider, so that if there's no `LAST-MODIFIED` field, the event gets the value of the  HTTP `Last-Modified` header as a fallback.