### PR TITLE
Add calendar config setters

### DIFF
--- a/caldir-core/src/caldir.rs
+++ b/caldir-core/src/caldir.rs
@@ -269,7 +269,7 @@ mod tests {
 
         let remote_config = test_remote_config("hooli");
         let mut config = test_calendar_config();
-        config.update_remote(remote_config);
+        config.set_remote(remote_config);
 
         caldir.create_calendar("work", Some(config)).unwrap();
         caldir.create_calendar("local-only", None).unwrap();
@@ -287,7 +287,7 @@ mod tests {
 
         let remote_config = test_remote_config("hooli");
         let mut config = test_calendar_config();
-        config.update_remote(remote_config);
+        config.set_remote(remote_config);
 
         caldir.create_calendar("work", Some(config)).unwrap();
 
@@ -310,11 +310,11 @@ mod tests {
         let caldir = Caldir::new(config, registry);
 
         let mut work_config = test_calendar_config();
-        work_config.update_remote(test_remote_config("hooli"));
+        work_config.set_remote(test_remote_config("hooli"));
         caldir.create_calendar("work", Some(work_config)).unwrap();
 
         let mut other_config = test_calendar_config();
-        other_config.update_remote(test_remote_config("aviato"));
+        other_config.set_remote(test_remote_config("aviato"));
         caldir.create_calendar("other", Some(other_config)).unwrap();
 
         let connected = caldir.connections();

--- a/caldir-core/src/calendar.rs
+++ b/caldir-core/src/calendar.rs
@@ -360,7 +360,7 @@ impl Calendar {
         self.remote_config().is_some()
     }
 
-    pub(crate) fn config(&self) -> Option<&CalendarConfig> {
+    pub fn config(&self) -> Option<&CalendarConfig> {
         self.config.as_ref()
     }
 

--- a/caldir-core/src/calendar/config.rs
+++ b/caldir-core/src/calendar/config.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 pub(crate) use error::CalendarConfigError;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct CalendarConfig {
     name: Option<String>,
     color: Option<String>,
@@ -61,8 +61,16 @@ impl CalendarConfig {
         self.name.as_deref()
     }
 
+    pub fn set_name(&mut self, name: Option<String>) {
+        self.name = name;
+    }
+
     pub fn color(&self) -> Option<&str> {
         self.color.as_deref()
+    }
+
+    pub fn set_color(&mut self, color: Option<String>) {
+        self.color = color;
     }
 
     pub fn read_only(&self) -> Option<bool> {
@@ -82,7 +90,7 @@ impl CalendarConfig {
     }
 
     #[cfg(test)]
-    pub(crate) fn update_remote(&mut self, remote_config: RemoteConfig) {
+    pub(crate) fn set_remote(&mut self, remote_config: RemoteConfig) {
         self.remote_config = Some(remote_config);
     }
 }
@@ -92,6 +100,21 @@ mod tests {
     use super::*;
     use crate::test_utils::test_calendar_config;
     use crate::{ProviderSlug, RemoteConfig, RemoteConfigParams};
+
+    #[test]
+    fn set_name_only_updates_name() {
+        let mut config = test_calendar_config();
+        let color = config.color.clone();
+        let read_only = config.read_only;
+        let remote_config = config.remote_config.clone();
+
+        config.set_name(Some("Renamed".to_string()));
+
+        assert_eq!(config.name(), Some("Renamed"));
+        assert_eq!(config.color, color);
+        assert_eq!(config.read_only, read_only);
+        assert_eq!(config.remote_config, remote_config);
+    }
 
     #[test]
     fn write_saves_config_to_file() {
@@ -202,26 +225,26 @@ hooli_calendar_id = "abc@group.calendar.hooli.com"
     }
 
     #[test]
-    fn update_remote_sets_remote_config() {
+    fn set_remote_sets_remote_config() {
         let mut config = test_calendar_config();
         assert!(config.remote_config().is_none());
 
         let remote = RemoteConfig::new(ProviderSlug::from("hooli"), RemoteConfigParams::new());
-        config.update_remote(remote.clone());
+        config.set_remote(remote.clone());
 
         assert_eq!(config.remote_config(), Some(&remote));
     }
 
     #[test]
-    fn update_remote_overwrites_existing_remote_config() {
+    fn set_remote_overwrites_existing_remote_config() {
         let mut config = test_calendar_config();
-        config.update_remote(RemoteConfig::new(
+        config.set_remote(RemoteConfig::new(
             ProviderSlug::from("hooli"),
             RemoteConfigParams::new(),
         ));
 
         let new_remote = RemoteConfig::new(ProviderSlug::from("aviato"), RemoteConfigParams::new());
-        config.update_remote(new_remote.clone());
+        config.set_remote(new_remote.clone());
 
         assert_eq!(config.remote_config(), Some(&new_remote));
     }


### PR DESCRIPTION
Clients using the caldir API (like [renCal](https://github.com/t4t5/rencal) should be able to let the user update a calendar's name or color easily.