### PR TITLE
Keep Google Meet links when splitting recurring series

### DIFF
--- a/caldir-provider-google/src/commands/create_event.rs
+++ b/caldir-provider-google/src/commands/create_event.rs
@@ -95,11 +95,11 @@ pub async fn handle(cmd: CreateEvent) -> Result<Event> {
     let mut google_event = cmd.event.to_google();
     google_event.id = String::new();
 
-    let response = client
+    let response = match client
         .events()
         .insert(
             calendar_id,
-            0,
+            1,
             0,
             false,
             SendUpdates::All,
@@ -107,11 +107,46 @@ pub async fn handle(cmd: CreateEvent) -> Result<Event> {
             &google_event,
         )
         .await
-        .with_context(|| format!("Failed to create event: {}", google_event.summary))?;
+    {
+        Ok(response) => Ok(response),
+        Err(error)
+            if google_event.conference_data.is_some() && is_conference_data_error(&error) =>
+        {
+            eprintln!(
+                "caldir-provider-google: warning: Google rejected copied conference data; \
+                 retrying without it: {error}"
+            );
+            google_event.conference_data = None;
+
+            client
+                .events()
+                .insert(
+                    calendar_id,
+                    1,
+                    0,
+                    false,
+                    SendUpdates::All,
+                    false,
+                    &google_event,
+                )
+                .await
+        }
+        Err(error) => Err(error),
+    }
+    .with_context(|| format!("Failed to create event: {}", google_event.summary))?;
 
     let created_event = Event::from_google(response.body)?;
 
     Ok(created_event)
+}
+
+fn is_conference_data_error(error: &google_calendar::ClientError) -> bool {
+    match error {
+        google_calendar::ClientError::HttpError { error, .. } => {
+            error.to_ascii_lowercase().contains("conference")
+        }
+        _ => false,
+    }
 }
 
 /// Format a `recurrence_id` as the suffix Google appends to a recurring
@@ -138,5 +173,33 @@ fn google_instance_suffix(rid: &EventTime) -> String {
             };
             utc.format("%Y%m%dT%H%M%SZ").to_string()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use google_calendar::{ClientError, HeaderMap, StatusCode};
+
+    fn http_error(message: &str) -> ClientError {
+        ClientError::HttpError {
+            status: StatusCode::BAD_REQUEST,
+            headers: HeaderMap::new(),
+            error: message.to_string(),
+        }
+    }
+
+    #[test]
+    fn identifies_conference_data_errors_for_insert_retry() {
+        let error = http_error(r#"{"error":{"message":"Invalid conferenceData value"}}"#);
+
+        assert!(is_conference_data_error(&error));
+    }
+
+    #[test]
+    fn does_not_retry_unrelated_insert_errors() {
+        let error = http_error(r#"{"error":{"message":"Invalid attendee email"}}"#);
+
+        assert!(!is_conference_data_error(&error));
     }
 }

--- a/caldir-provider-google/src/google_event/to_google.rs
+++ b/caldir-provider-google/src/google_event/to_google.rs
@@ -86,6 +86,10 @@ impl ToGoogle for Event {
             .unwrap_or_default()
             .to_string();
 
+        let conference_data = self
+            .x_property("X-GOOGLE-CONFERENCE")
+            .and_then(google_meet_conference_data);
+
         google_calendar::types::Event {
             id: google_event_id,
             i_cal_uid: self.uid.as_str().to_string(),
@@ -103,9 +107,52 @@ impl ToGoogle for Event {
             original_start_time,
             sequence: self.sequence as i64,
             color_id,
+            conference_data,
             ..Default::default()
         }
     }
+}
+
+fn google_meet_conference_data(url: &str) -> Option<google_calendar::types::ConferenceData> {
+    let parsed = url::Url::parse(url).ok()?;
+    if parsed.scheme() != "https" || parsed.host_str() != Some("meet.google.com") {
+        return None;
+    }
+
+    let mut path_segments = parsed
+        .path_segments()?
+        .filter(|segment| !segment.is_empty());
+    let conference_id = path_segments.next()?;
+    if path_segments.next().is_some() {
+        return None;
+    }
+
+    Some(google_calendar::types::ConferenceData {
+        conference_id: conference_id.to_string(),
+        conference_solution: Some(google_calendar::types::ConferenceSolution {
+            icon_uri: String::new(),
+            key: Some(google_calendar::types::ConferenceSolutionKey {
+                type_: "hangoutsMeet".to_string(),
+            }),
+            name: String::new(),
+        }),
+        entry_points: vec![google_calendar::types::EntryPoint {
+            access_code: String::new(),
+            entry_point_features: Vec::new(),
+            entry_point_type: "video".to_string(),
+            label: String::new(),
+            meeting_code: String::new(),
+            passcode: String::new(),
+            password: String::new(),
+            pin: String::new(),
+            region_code: String::new(),
+            uri: url.to_string(),
+        }],
+        create_request: None,
+        notes: String::new(),
+        parameters: None,
+        signature: String::new(),
+    })
 }
 
 fn attendee_to_google(attendee: &Attendee) -> google_calendar::types::EventAttendee {
@@ -197,7 +244,7 @@ pub(crate) fn participation_status_to_google(status: ParticipationStatus) -> &'s
 #[cfg(test)]
 mod tests {
     use super::*;
-    use caldir_core::{Event, EventTime, Reminder, Visibility};
+    use caldir_core::{Event, EventTime, Reminder, Visibility, XProperty};
     use chrono::NaiveDate;
 
     fn sample_event() -> Event {
@@ -284,6 +331,46 @@ mod tests {
 
         assert!(reminders.use_default);
         assert!(reminders.overrides.is_empty());
+    }
+
+    #[test]
+    fn google_meet_x_property_populates_conference_data() {
+        let url = "https://meet.google.com/abc-defg-hij";
+        let mut event = sample_event();
+        event.x_properties = vec![XProperty::new("X-GOOGLE-CONFERENCE", url)];
+
+        let google = event.to_google();
+        let conference = google
+            .conference_data
+            .expect("Google Meet conference data should be preserved");
+
+        assert_eq!(conference.conference_id, "abc-defg-hij");
+        assert_eq!(
+            conference
+                .conference_solution
+                .and_then(|solution| solution.key)
+                .map(|key| key.type_),
+            Some("hangoutsMeet".to_string())
+        );
+        assert_eq!(conference.entry_points.len(), 1);
+        assert_eq!(conference.entry_points[0].entry_point_type, "video");
+        assert_eq!(conference.entry_points[0].uri, url);
+    }
+
+    #[test]
+    fn non_google_meet_x_property_does_not_populate_conference_data() {
+        let mut event = sample_event();
+        event.x_properties = vec![XProperty::new(
+            "X-GOOGLE-CONFERENCE",
+            "https://zoom.us/j/123456789",
+        )];
+
+        assert!(event.to_google().conference_data.is_none());
+    }
+
+    #[test]
+    fn event_without_conference_x_property_has_no_conference_data() {
+        assert!(sample_event().to_google().conference_data.is_none());
     }
 
     #[test]


### PR DESCRIPTION
**Bug:** Splitting a recurring Google event with "All future events" silently dropped the Meet link from the new series. 👎

**What was happening:** 
An "all future events" edit splits the series into a truncated old event and a brand-new one.

When pushing that new event, `to_google()` never mapped the conference data, and we called insert with `conferenceDataVersion=0`, which tells Google to ignore all conference data.

The new series was therefore born *without* a Meet link (even if the original had one) and the stripped version synced back down to everyone.

**The fix:**

- `to_google()` now rebuilds conferenceData from the `X-GOOGLE-CONFERENCE` x-property (Meet URLs only, third-party links can't be faithfully reconstructed from a bare URL)
- insert now passes `conferenceDataVersion=1` so Google actually accepts it
- If Google rejects the conference payload (e.g. tenant has Meet disabled), we retry once without it. A missing link is still better than a permanently broken sync
