### PR TITLE
Optionally request new Google Meet URL when creating event

### DIFF
--- a/caldir-provider-google/README.md
+++ b/caldir-provider-google/README.md
@@ -1,0 +1,39 @@
+# Google Calendar provider
+
+## Sync behavior
+
+Recurring events are fetched with `singleEvents=false`, preserving each series
+as a master with an `RRULE` instead of expanding every occurrence.
+
+Only explicit event reminder overrides are stored. Google calendar-level
+default reminders are not copied into individual events.
+
+## Google-specific ICS properties
+
+### `X-GOOGLE-EVENT-ID`
+
+Google identifies events with its own internal ID, separate from the RFC 5545
+`UID`. The provider stores that ID in `X-GOOGLE-EVENT-ID` when pulling an event
+and uses it for later updates and deletes.
+
+### `X-GOOGLE-CONFERENCE`
+
+`X-GOOGLE-CONFERENCE` stores a Google Meet URL when an event is pulled from
+Google. Its value comes from the video entry point in
+`conferenceData.entryPoints`. The provider rebuilds Google's conference data
+from this property when the event is pushed.
+
+An empty or whitespace-only value requests a new Meet link:
+
+```ics
+X-GOOGLE-CONFERENCE:
+```
+
+On the next push, Google creates the conference and the provider replaces the
+empty property with the resulting Meet URL. The request ID combines the event
+UID and sequence, making retries idempotent while allowing a later event
+revision to request a different conference.
+
+If Google rejects conference creation, the provider retries new event creation
+without conference data. The empty property is then dropped during the
+round-trip.

--- a/caldir-provider-google/src/commands/create_event.rs
+++ b/caldir-provider-google/src/commands/create_event.rs
@@ -113,7 +113,7 @@ pub async fn handle(cmd: CreateEvent) -> Result<Event> {
             if google_event.conference_data.is_some() && is_conference_data_error(&error) =>
         {
             eprintln!(
-                "caldir-provider-google: warning: Google rejected copied conference data; \
+                "caldir-provider-google: warning: Google rejected conference data; \
                  retrying without it: {error}"
             );
             google_event.conference_data = None;

--- a/caldir-provider-google/src/commands/update_event.rs
+++ b/caldir-provider-google/src/commands/update_event.rs
@@ -67,7 +67,8 @@ async fn patch_event_without_attendees(
     let body = patch_body_without_attendees(event)?;
 
     let url = format!(
-        "https://www.googleapis.com/calendar/v3/calendars/{}/events/{}?sendUpdates=all",
+        "https://www.googleapis.com/calendar/v3/calendars/{}/events/{}?\
+         sendUpdates=all&conferenceDataVersion=1",
         calendar_id, event_id,
     );
 

--- a/caldir-provider-google/src/commands/update_event.rs
+++ b/caldir-provider-google/src/commands/update_event.rs
@@ -115,6 +115,7 @@ mod tests {
         let body = patch_body_without_attendees(&event).unwrap();
 
         assert!(body.get("attendees").is_none());
+        assert!(body.get("conferenceData").is_none());
         assert_eq!(
             body.get("summary").and_then(Value::as_str),
             Some("Weekly sync")

--- a/caldir-provider-google/src/google_event/to_google.rs
+++ b/caldir-provider-google/src/google_event/to_google.rs
@@ -86,9 +86,9 @@ impl ToGoogle for Event {
             .unwrap_or_default()
             .to_string();
 
-        let conference_data = self
-            .x_property("X-GOOGLE-CONFERENCE")
-            .and_then(google_meet_conference_data);
+        let conference_data = self.x_property("X-GOOGLE-CONFERENCE").and_then(|url| {
+            google_meet_conference_data(url, &format!("{}-{}", self.uid.as_str(), self.sequence))
+        });
 
         google_calendar::types::Event {
             id: google_event_id,
@@ -113,7 +113,28 @@ impl ToGoogle for Event {
     }
 }
 
-fn google_meet_conference_data(url: &str) -> Option<google_calendar::types::ConferenceData> {
+fn google_meet_conference_data(
+    url: &str,
+    request_id: &str,
+) -> Option<google_calendar::types::ConferenceData> {
+    if url.trim().is_empty() {
+        return Some(google_calendar::types::ConferenceData {
+            conference_id: String::new(),
+            conference_solution: None,
+            entry_points: Vec::new(),
+            create_request: Some(google_calendar::types::CreateConferenceRequest {
+                conference_solution_key: Some(google_calendar::types::ConferenceSolutionKey {
+                    type_: "hangoutsMeet".to_string(),
+                }),
+                request_id: request_id.to_string(),
+                status: None,
+            }),
+            notes: String::new(),
+            parameters: None,
+            signature: String::new(),
+        });
+    }
+
     let parsed = url::Url::parse(url).ok()?;
     if parsed.scheme() != "https" || parsed.host_str() != Some("meet.google.com") {
         return None;
@@ -355,6 +376,48 @@ mod tests {
         assert_eq!(conference.entry_points.len(), 1);
         assert_eq!(conference.entry_points[0].entry_point_type, "video");
         assert_eq!(conference.entry_points[0].uri, url);
+        assert!(conference.create_request.is_none());
+    }
+
+    #[test]
+    fn empty_google_meet_x_property_requests_conference_creation() {
+        let mut event = sample_event();
+        event.sequence = 3;
+        event.x_properties = vec![XProperty::new("X-GOOGLE-CONFERENCE", "")];
+        let expected_request_id = format!("{}-3", event.uid.as_str());
+
+        let google = event.to_google();
+        let conference = google
+            .conference_data
+            .expect("empty Google Meet property should request a conference");
+        let request = conference
+            .create_request
+            .expect("conference creation request should be populated");
+
+        assert!(conference.entry_points.is_empty());
+        assert!(conference.conference_solution.is_none());
+        assert_eq!(request.request_id, expected_request_id);
+        assert_eq!(
+            request
+                .conference_solution_key
+                .map(|key| key.type_)
+                .as_deref(),
+            Some("hangoutsMeet")
+        );
+    }
+
+    #[test]
+    fn whitespace_google_meet_x_property_requests_conference_creation() {
+        let mut event = sample_event();
+        event.x_properties = vec![XProperty::new("X-GOOGLE-CONFERENCE", " \t ")];
+
+        let conference = event
+            .to_google()
+            .conference_data
+            .expect("whitespace Google Meet property should request a conference");
+
+        assert!(conference.create_request.is_some());
+        assert!(conference.entry_points.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
We want users to be able to create new Google Calendar events with a Google Meet URL attached.

A clean and unambiguous way of doing it is to create an ICS file with an empty `X-GOOGLE-CONFERENCE` property. 

`caldir-provider-google` will then interpet that as:  "create a new google meet URL for this event"