### PR TITLE
Fix: deleting instance of all-day event in non-UTC timezone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
 
-# On pushes to main, CI runs via workflow_call from release.yml,
-# which gates releasing and publishing on it.
 on:
   pull_request:
   workflow_call:
@@ -36,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # UTC plus one zone east and one west of it, to catch timezone-dependent bugs
+        # UTC + one zone east + one zone west (to catch timezone-dependent bugs)
         tz: [UTC, Europe/Stockholm, America/New_York]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
 
+# On pushes to main, CI runs via workflow_call from release.yml,
+# which gates releasing and publishing on it.
 on:
   pull_request:
-  push:
-    branches: [main]
+  workflow_call:
 
 jobs:
   fmt:
@@ -30,6 +31,26 @@ jobs:
 
       - name: Run just check
         run: just check
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        # UTC plus one zone east and one west of it, to catch timezone-dependent bugs
+        tz: [UTC, Europe/Stockholm, America/New_York]
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      TZ: ${{ matrix.tz }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run just test
         run: just test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,6 @@ jobs:
             --generate-notes
 
   publish:
-    # Runs even when no CLI release happened (crate-only bumps), but never
-    # when CI or any release job failed.
     needs: [ci, release]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
   check-cli-version:
     runs-on: ubuntu-latest
     outputs:
@@ -33,7 +36,7 @@ jobs:
           fi
 
   build:
-    needs: check-cli-version
+    needs: [check-cli-version, ci]
     if: needs.check-cli-version.outputs.should_release == 'true'
     strategy:
       matrix:
@@ -96,7 +99,9 @@ jobs:
             --generate-notes
 
   publish:
-    needs: release
+    # Runs even when no CLI release happened (crate-only bumps), but never
+    # when CI or any release job failed.
+    needs: [ci, release]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/caldir-core/src/event/occurrences.rs
+++ b/caldir-core/src/event/occurrences.rs
@@ -192,8 +192,6 @@ fn format_dtstart(start: &EventTime) -> String {
 
 fn format_exdate_or_rdate(name: &str, time: &EventTime, start: &EventTime) -> String {
     match (start, time) {
-        // A date is a date — converting via to_utc() would shift it by the
-        // machine's UTC offset (e.g. Jan 12 → Jan 11 east of UTC).
         (_, EventTime::Date(d)) => format!("{};VALUE=DATE:{}", name, d.format("%Y%m%d")),
         (EventTime::Date(_), _) => {
             format!("{};VALUE=DATE:{}", name, time.to_utc().format("%Y%m%d"))

--- a/caldir-core/src/event/occurrences.rs
+++ b/caldir-core/src/event/occurrences.rs
@@ -192,10 +192,12 @@ fn format_dtstart(start: &EventTime) -> String {
 
 fn format_exdate_or_rdate(name: &str, time: &EventTime, start: &EventTime) -> String {
     match (start, time) {
+        // A date is a date — converting via to_utc() would shift it by the
+        // machine's UTC offset (e.g. Jan 12 → Jan 11 east of UTC).
+        (_, EventTime::Date(d)) => format!("{};VALUE=DATE:{}", name, d.format("%Y%m%d")),
         (EventTime::Date(_), _) => {
             format!("{};VALUE=DATE:{}", name, time.to_utc().format("%Y%m%d"))
         }
-        (_, EventTime::Date(d)) => format!("{};VALUE=DATE:{}", name, d.format("%Y%m%d")),
         (_, EventTime::DateTimeUtc(dt)) => {
             format!("{}:{}", name, dt.format("%Y%m%dT%H%M%SZ"))
         }


### PR DESCRIPTION
Noticed that I couldn't delete an instance of a recurring all-day event when travelling.

Turns out all-day EXDATEs were converted through local-midnight-to-UTC before formatting, shifting them a day back on machines east of UTC, so excluded instances reappeared. A date is now formatted as-is.

This PR also makes sure that tests are run in different timezones to catch this bug before a release next time!