### PR TITLE
Add "caldir calendars" command

### DIFF
--- a/caldir-cli/src/commands/calendars.rs
+++ b/caldir-cli/src/commands/calendars.rs
@@ -1,0 +1,82 @@
+use anyhow::Result;
+use caldir_core::{Caldir, CaldirError, Calendar};
+
+use crate::output::calendars::{CalendarView, CalendarsView};
+
+pub fn run(caldir: &Caldir) -> Result<CalendarsView> {
+    build_view(caldir.calendars())
+}
+
+fn build_view(calendars: Vec<Result<Calendar, CaldirError>>) -> Result<CalendarsView> {
+    let mut calendars = calendars.into_iter().collect::<Result<Vec<_>, _>>()?;
+    calendars.sort_by(|a, b| a.slug().cmp(&b.slug()));
+
+    Ok(CalendarsView(
+        calendars.into_iter().map(CalendarView::from).collect(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{Output, TextRender};
+    use caldir_core::{CalendarConfig, ProviderSlug, RemoteConfig, RemoteConfigParams};
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn renders_connected_and_local_calendars_ordered_by_slug() {
+        let tmp = tempfile::tempdir().unwrap();
+        let remote = RemoteConfig::new(ProviderSlug::from("google"), RemoteConfigParams::new());
+        let config = CalendarConfig::new(
+            Some("Personal".to_string()),
+            Some("#4285f4".to_string()),
+            Some(true),
+            Some(remote),
+        );
+        let connected = Calendar::create(&tmp.path().join("personal"), Some(config)).unwrap();
+        let local = Calendar::create(&tmp.path().join("local-notes"), None).unwrap();
+
+        let view = build_view(vec![Ok(connected), Ok(local)]).unwrap();
+
+        assert_eq!(
+            view.to_text(),
+            indoc! {r#"
+                local-notes
+                  name: -
+                  color: -
+                  read only: no
+                  provider: -
+
+                personal
+                  name: Personal
+                  color: #4285f4
+                  read only: yes
+                  provider: google"#}
+        );
+
+        let json = view.to_json();
+        assert_eq!(json[0]["slug"], "local-notes");
+        assert_eq!(json[0]["name"], serde_json::Value::Null);
+        assert_eq!(json[0]["color"], serde_json::Value::Null);
+        assert_eq!(json[0]["read_only"], false);
+        assert_eq!(json[0]["provider"], serde_json::Value::Null);
+        assert_eq!(json[1]["slug"], "personal");
+        assert_eq!(json[1]["name"], "Personal");
+        assert_eq!(json[1]["color"], "#4285f4");
+        assert_eq!(json[1]["read_only"], true);
+        assert_eq!(json[1]["provider"], "google");
+    }
+
+    #[test]
+    fn invalid_calendar_config_returns_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let calendar_path = tmp.path().join("broken");
+        std::fs::create_dir_all(calendar_path.join(".caldir")).unwrap();
+        std::fs::write(calendar_path.join(".caldir/config.toml"), "not valid toml").unwrap();
+
+        let calendar = Calendar::load(&calendar_path).map_err(CaldirError::from);
+
+        assert!(build_view(vec![calendar]).is_err());
+    }
+}

--- a/caldir-cli/src/commands/mod.rs
+++ b/caldir-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod calendars;
 pub mod config;
 pub mod connect;
 pub mod discard;

--- a/caldir-cli/src/main.rs
+++ b/caldir-cli/src/main.rs
@@ -212,6 +212,8 @@ enum Commands {
     },
     #[command(about = "Show configuration paths and calendar info")]
     Config,
+    #[command(about = "List configured calendars")]
+    Calendars,
     #[command(about = "Check your caldir for bad data (e.g. duplicate files)")]
     Doctor,
     #[command(about = "Update caldir and installed providers to the latest version")]
@@ -222,7 +224,11 @@ impl Commands {
     fn supports_json(&self) -> bool {
         matches!(
             self,
-            Self::Config | Self::Events { .. } | Self::Today { .. } | Self::Week { .. }
+            Self::Calendars
+                | Self::Config
+                | Self::Events { .. }
+                | Self::Today { .. }
+                | Self::Week { .. }
         )
     }
 }
@@ -327,6 +333,11 @@ async fn main() -> Result<()> {
             output::emit(&view, output_format);
             Ok(())
         }
+        Commands::Calendars => {
+            let view = commands::calendars::run(&caldir)?;
+            output::emit(&view, output_format);
+            Ok(())
+        }
         Commands::Doctor => commands::doctor::run(&caldir),
         Commands::Update => unreachable!("handled above"),
     }
@@ -365,6 +376,7 @@ mod tests {
 
     #[test]
     fn views_support_json() {
+        assert!(Commands::Calendars.supports_json());
         assert!(Commands::Config.supports_json());
         assert!(
             Commands::Events {

--- a/caldir-cli/src/output.rs
+++ b/caldir-cli/src/output.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 pub mod agenda;
 mod agenda_json;
 mod agenda_text;
+pub mod calendars;
 pub mod config;
 pub mod diff;
 pub mod event;

--- a/caldir-cli/src/output/calendars.rs
+++ b/caldir-cli/src/output/calendars.rs
@@ -1,0 +1,69 @@
+use caldir_core::Calendar;
+use serde::Serialize;
+
+use crate::output::TextRender;
+
+#[derive(Serialize)]
+pub struct CalendarView {
+    pub slug: String,
+    pub name: Option<String>,
+    pub color: Option<String>,
+    pub read_only: bool,
+    pub provider: Option<String>,
+}
+
+impl From<Calendar> for CalendarView {
+    fn from(calendar: Calendar) -> Self {
+        Self {
+            slug: calendar.slug().unwrap_or_default().to_string(),
+            name: calendar.name().map(str::to_string),
+            color: calendar.color().map(str::to_string),
+            read_only: calendar.is_read_only(),
+            provider: calendar
+                .remote_config()
+                .map(|remote| remote.provider_slug().to_string()),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(transparent)]
+pub struct CalendarsView(pub Vec<CalendarView>);
+
+impl TextRender for CalendarsView {
+    fn to_text(&self) -> String {
+        if self.0.is_empty() {
+            return "No calendars found.".to_string();
+        }
+
+        self.0
+            .iter()
+            .map(|calendar| {
+                format!(
+                    "{}\n  name: {}\n  color: {}\n  read only: {}\n  provider: {}",
+                    calendar.slug,
+                    calendar.name.as_deref().unwrap_or("-"),
+                    calendar.color.as_deref().unwrap_or("-"),
+                    if calendar.read_only { "yes" } else { "no" },
+                    calendar.provider.as_deref().unwrap_or("-")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{Output, TextRender};
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn empty_view_renders_text_and_json() {
+        let view = CalendarsView(vec![]);
+
+        assert_eq!(view.to_text(), "No calendars found.");
+        assert_eq!(view.to_json(), serde_json::json!([]));
+    }
+}

--- a/website/src/content/docs/commands.md
+++ b/website/src/content/docs/commands.md
@@ -226,6 +226,21 @@ caldir discard --calendar work
 caldir discard --force
 ```
 
+## `caldir calendars`
+
+List every calendar in the local caldir together with its stored name, color,
+read-only setting, and provider.
+
+```bash
+caldir calendars
+
+# As JSON
+caldir calendars --json
+```
+
+This command reads local calendar configuration only. It does not contact
+providers or inspect events.
+
 ## `caldir config`
 
 Show configuration paths and calendar info.


### PR DESCRIPTION
Make it easy to see your configured calendars.

Example output:

```console
$ caldir calendars

icloud
  name: Family
  color: #ff9500
  read only: no
  provider: icloud

personal
  name: Personal
  color: #4285f4
  read only: no
  provider: google
```

JSON output:

```console
$ caldir calendars --json

[
  {
    "slug": "icloud",
    "name": "Family",
    "color": "#ff9500",
    "read_only": false,
    "provider": "icloud"
  },
  {
    "slug": "personal",
    "name": "Personal",
    "color": "#4285f4",
    "read_only": false,
    "provider": "google"
  }
]
```