### PR TITLE
Add `--timeout` option

### DIFF
--- a/caldir-cli/src/main.rs
+++ b/caldir-cli/src/main.rs
@@ -18,6 +18,10 @@ struct Cli {
     /// Output as JSON
     #[arg(long, global = true)]
     json: bool,
+
+    /// Provider response timeout (e.g. "30s", "2m")
+    #[arg(long, global = true, value_parser = humantime::parse_duration)]
+    timeout: Option<std::time::Duration>,
 }
 
 #[derive(Subcommand)]
@@ -254,6 +258,10 @@ async fn main() -> Result<()> {
 
     let mut caldir = Caldir::load()?;
 
+    if let Some(timeout) = cli.timeout {
+        caldir.set_provider_timeout(timeout);
+    }
+
     match cli.command {
         Commands::Connect { provider, hosted } => {
             commands::connect::run(&mut caldir, provider, hosted).await
@@ -372,6 +380,20 @@ mod tests {
             "google"
         ]));
         assert!(parse_hosted(&["caldir", "connect", "google"]));
+    }
+
+    #[test]
+    fn timeout_parses_human_readable_duration() {
+        let cli = Cli::parse_from(["caldir", "status", "--timeout", "30s"]);
+
+        assert_eq!(cli.timeout, Some(std::time::Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn timeout_defaults_to_none() {
+        let cli = Cli::parse_from(["caldir", "status"]);
+
+        assert_eq!(cli.timeout, None);
     }
 
     #[test]

--- a/caldir-core/src/caldir.rs
+++ b/caldir-core/src/caldir.rs
@@ -44,6 +44,11 @@ impl Caldir {
         self
     }
 
+    /// Override the RPC timeout for all providers.
+    pub fn set_provider_timeout(&mut self, timeout: std::time::Duration) {
+        self.providers.set_timeout(timeout);
+    }
+
     pub fn data_dir(&self) -> PathBuf {
         self.config.data_dir()
     }

--- a/caldir-core/src/provider.rs
+++ b/caldir-core/src/provider.rs
@@ -13,6 +13,7 @@ use crate::rpc;
 use account::ProviderAccount;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 use transport::{ProviderTransport, SubprocessTransport};
 
 pub(crate) use error::ProviderError;
@@ -25,6 +26,7 @@ pub use storage::{ProviderStorage, StorageError};
 pub struct Provider {
     slug: ProviderSlug,
     transport: Arc<dyn ProviderTransport>,
+    timeout: Option<Duration>,
 }
 
 impl Provider {
@@ -46,11 +48,16 @@ impl Provider {
         Ok(Provider {
             slug,
             transport: Arc::new(transport),
+            timeout: None,
         })
     }
 
     pub fn slug(&self) -> &ProviderSlug {
         &self.slug
+    }
+
+    pub(crate) fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = Some(timeout);
     }
 
     pub fn provider_account(&self, identifier: String) -> ProviderAccount {
@@ -76,7 +83,8 @@ impl Provider {
             serde_json::to_string(&request_value).map_err(ProviderError::Serialize)?;
 
         // Make call:
-        let response_json = self.transport.exchange(&request_json, C::TIMEOUT).await?;
+        let timeout = self.timeout.unwrap_or(C::TIMEOUT);
+        let response_json = self.transport.exchange(&request_json, timeout).await?;
 
         let response: rpc::Response<rpc::Wire<C::Response>> =
             serde_json::from_str(&response_json).map_err(ProviderError::Deserialize)?;
@@ -92,7 +100,11 @@ impl Provider {
         slug: ProviderSlug,
         transport: Arc<dyn ProviderTransport>,
     ) -> Self {
-        Provider { slug, transport }
+        Provider {
+            slug,
+            transport,
+            timeout: None,
+        }
     }
 
     #[cfg(test)]
@@ -248,6 +260,22 @@ mod tests {
             .unwrap();
 
         assert_eq!(mock.captured_timeout(), Some(Duration::from_secs(7)));
+    }
+
+    #[tokio::test]
+    async fn call_prefers_configured_timeout_over_per_command_timeout() {
+        let mock = Arc::new(MockTransport::with_response(
+            r#"{"status":"success","data":{"value":"x"}}"#,
+        ));
+        let mut provider = provider_with_transport(mock.clone());
+        provider.set_timeout(Duration::from_secs(30));
+
+        provider
+            .call(EchoCommand { value: "x".into() })
+            .await
+            .unwrap();
+
+        assert_eq!(mock.captured_timeout(), Some(Duration::from_secs(30)));
     }
 
     #[tokio::test]

--- a/caldir-core/src/provider/registry.rs
+++ b/caldir-core/src/provider/registry.rs
@@ -2,6 +2,7 @@ use super::error::ProviderError;
 use crate::{Provider, ProviderSlug};
 use std::collections::HashMap;
 use std::path::Path;
+use std::time::Duration;
 
 use super::slug::PROVIDER_BINARY_PREFIX;
 
@@ -32,6 +33,13 @@ impl ProviderRegistry {
 
     pub fn add(&mut self, provider: Provider) {
         self.0.insert(provider.slug().clone(), provider);
+    }
+
+    /// Override the RPC timeout for all registered providers.
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        for provider in self.0.values_mut() {
+            provider.set_timeout(timeout);
+        }
     }
 
     /// Slugs of all registered providers. Order is not stable.


### PR DESCRIPTION
Fixes #56

Let users specify how long they want a provider request to go on before it times out (can be useful when calling APIs that are expected to take a long time). If not set, it defaults to 15s like before.

Example:

```bash
caldir status --timeout=30s
```