### PR TITLE
Refactor outlook provider

### DIFF
--- a/.agents/skills/provider-rpc/SKILL.md
+++ b/.agents/skills/provider-rpc/SKILL.md
@@ -130,7 +130,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 Picking the right endpoint matters — Graph has three with very different semantics:
 
 - `/me/calendars/{id}/events` — series **masters** and **standalones** only. Does NOT include exceptions or expanded occurrences. Best for "what discrete events does this calendar contain".
-- `/me/events/{master_id}/instances?startDateTime=...&endDateTime=...` — every occurrence of one series in the window, including overrides. Each item carries a `type` field: `occurrence` (auto-expanded, identical to master) or `exception` (overridden). caldir's `list_events` calls this once per master and keeps only `type=exception`.
+- `/me/events/{master_id}/instances?startDateTime=...&endDateTime=...` — every occurrence of one series in the window, including overrides. Each item carries a `type` field: `occurrence` (auto-expanded, identical to master) or `exception` (overridden). caldir's `list_events` calls this for masters represented in `calendarView` and keeps only `type=exception`.
 - `/me/calendarView?startDateTime=...&endDateTime=...` — every occurrence of every series, fully expanded. Convenient for "show me the calendar" but a long-running weekly meeting becomes ~50 indistinguishable rows, so caldir avoids it.
 
 URL gotcha: Graph rejects RFC3339 timestamps containing `+` (e.g. `2026-05-01T16:00:00+00:00`) because URL-decoders read `+` as a space. Use the `Z` form (`2026-05-01T16:00:00Z`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "caldir-core",
  "chrono",
  "chrono-tz",
+ "futures",
  "html2text",
  "reqwest",
  "serde",

--- a/caldir-provider-outlook/AGENTS.md
+++ b/caldir-provider-outlook/AGENTS.md
@@ -6,9 +6,11 @@ Outlook / Microsoft 365 provider via the Microsoft Graph API. Same provider cont
 
 Same two-mode setup as Google: **hosted** (OAuth flows through `caldir.org`, no Azure AD app needed) or **self-hosted** (`--hosted=false`, user registers their own app and ships client_id/secret in `app_config.toml`). The mode is recorded on the session so refresh knows which endpoint to hit.
 
-## Calendar view discovery vs. event data
+## Hybrid event discovery
 
-`list_events` uses `calendarView` only as a window-bounded discovery index, selecting event IDs and types. Its expanded occurrences are never converted into caldir events: occurrence and exception rows point back to their series master, which is fetched in full from `/events/{id}`. This preserves caldir's natural shape of one recurring master with its `recurrence` pattern, plus exception overrides fetched from `/instances`.
+`list_events` uses `calendarView` as a window-bounded discovery index for standalone events and recurring instances. A compact `/events?$select=id,type&$filter=type eq 'seriesMaster'` index separately discovers every series master, so an existing series cannot look deleted merely because none of its instances remains in the requested window. The union is fetched in full from `/events/{id}`.
+
+Expanded `calendarView` occurrences are never converted into caldir events: occurrence and exception rows point back to their series master. Only masters represented in the requested window incur an `/instances` request for exception overrides. This preserves caldir's natural shape of one recurring master with its `recurrence` pattern plus its exceptions, without expanding every historical series.
 
 Do not replace discovery with a date filter on `/events`. OData filters only see a series master's *first* occurrence, so a long-running meeting started in 2020 would be excluded from a 2026 window.
 

--- a/caldir-provider-outlook/AGENTS.md
+++ b/caldir-provider-outlook/AGENTS.md
@@ -6,11 +6,11 @@ Outlook / Microsoft 365 provider via the Microsoft Graph API. Same provider cont
 
 Same two-mode setup as Google: **hosted** (OAuth flows through `caldir.org`, no Azure AD app needed) or **self-hosted** (`--hosted=false`, user registers their own app and ships client_id/secret in `app_config.toml`). The mode is recorded on the session so refresh knows which endpoint to hit.
 
-## Why `/events`, not `/calendarView`
+## Calendar view discovery vs. event data
 
-Graph's `calendarView` *expands* every recurring occurrence into its own event with a synthetic `iCalUId`, turning one weekly meeting into ~50 indistinguishable rows. `/events` returns the natural shape — series masters with their `recurrence` pattern, plus exception overrides — which maps cleanly to caldir's one-file-per-logical-event model.
+`list_events` uses `calendarView` only as a window-bounded discovery index, selecting event IDs and types. Its expanded occurrences are never converted into caldir events: occurrence and exception rows point back to their series master, which is fetched in full from `/events/{id}`. This preserves caldir's natural shape of one recurring master with its `recurrence` pattern, plus exception overrides fetched from `/instances`.
 
-We deliberately don't pass a date filter: OData filters only see a series master's *first* occurrence, so a long-running meeting started in 2020 would be excluded from a 2026 window. We pull everything and let core enforce the ±365-day window.
+Do not replace discovery with a date filter on `/events`. OData filters only see a series master's *first* occurrence, so a long-running meeting started in 2020 would be excluded from a 2026 window.
 
 ## Recurring identity
 

--- a/caldir-provider-outlook/Cargo.toml
+++ b/caldir-provider-outlook/Cargo.toml
@@ -19,6 +19,7 @@ caldir-core = { path = "../caldir-core", version = "0.14.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
+futures = "0.3"
 
 # HTTP client (Graph API + OAuth)
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
@@ -46,4 +47,3 @@ html2text = "0.17"
 
 [dev-dependencies]
 tempfile = "3"
-

--- a/caldir-provider-outlook/src/commands/list_events.rs
+++ b/caldir-provider-outlook/src/commands/list_events.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result, bail};
 use caldir_core::Event;
@@ -10,7 +10,7 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use crate::app_config::AppConfigStore;
 use crate::constants::PROVIDER_NAME;
 use crate::graph_api::client::GraphClient;
-use crate::graph_api::types::{CalendarViewRow, GraphEvent};
+use crate::graph_api::types::{CalendarViewRow, GraphEvent, SeriesMasterIndexRow};
 use crate::outlook_event::from_outlook::from_outlook;
 use crate::remote_config::OutlookRemoteConfig;
 use crate::session::SessionStore;
@@ -32,10 +32,16 @@ pub async fn handle(cmd: ListEvents) -> Result<Vec<Event>> {
     let to = normalize_window_bound(&cmd.to)
         .with_context(|| format!("Invalid `to` timestamp: {}", cmd.to))?;
 
-    // Discover IDs with `/calendarView`, then fetch only those logical events
-    // in full. Recurring exceptions still come from each master's `/instances`.
-    let event_ids =
-        discover_window_event_ids(&graph, &config.outlook_calendar_id, &from, &to).await?;
+    let (window, indexed_master_ids) = tokio::try_join!(
+        discover_window_events(&graph, &config.outlook_calendar_id, &from, &to),
+        discover_series_master_ids(&graph, &config.outlook_calendar_id),
+    )?;
+    let event_ids = merge_event_ids(&window.event_ids, &indexed_master_ids);
+    let expected_master_ids: HashSet<&str> = indexed_master_ids
+        .iter()
+        .map(String::as_str)
+        .chain(window.master_ids.iter().map(String::as_str))
+        .collect();
 
     let graph_events: Vec<GraphEvent> = stream::iter(event_ids.into_iter().map(|event_id| {
         let graph = &graph;
@@ -50,7 +56,7 @@ pub async fn handle(cmd: ListEvents) -> Result<Vec<Event>> {
     // exception's iCalUId so masters and their overrides share the same UID
     // locally (RFC 5545 — Graph mints unique iCalUIds per exception, which
     // would otherwise break the (uid, recurrence_id) sync key).
-    let mut master_ids = Vec::new();
+    let mut master_uids = HashMap::new();
 
     for graph_event in graph_events {
         let outlook_id = graph_event.id.clone();
@@ -58,19 +64,41 @@ pub async fn handle(cmd: ListEvents) -> Result<Vec<Event>> {
         let is_master =
             graph_event.event_type == "seriesMaster" || graph_event.recurrence.is_some();
 
+        if expected_master_ids.contains(outlook_id.as_str())
+            && graph_event.event_type != "seriesMaster"
+        {
+            bail!("Expected event {outlook_id} to be a series master");
+        }
+
         match from_outlook(graph_event, &config.outlook_account) {
             Ok(event) => {
                 if is_master {
-                    master_ids.push((outlook_id, master_uid));
+                    master_uids.insert(outlook_id, master_uid);
                 }
                 all_events.push(event);
             }
-            Err(_) => continue, // Skip malformed events
+            Err(error) if expected_master_ids.contains(outlook_id.as_str()) => {
+                return Err(error).with_context(|| {
+                    format!("Failed to convert expected series master {outlook_id}")
+                });
+            }
+            Err(_) => continue,
         }
     }
 
+    let window_masters: Vec<(String, String)> = window
+        .master_ids
+        .iter()
+        .map(|master_id| {
+            let master_uid = master_uids.get(master_id).with_context(|| {
+                format!("Window series master {master_id} was not fetched successfully")
+            })?;
+            Ok((master_id.clone(), master_uid.clone()))
+        })
+        .collect::<Result<_>>()?;
+
     let exception_sets: Vec<Vec<GraphEvent>> =
-        stream::iter(master_ids.into_iter().map(|(master_id, master_uid)| {
+        stream::iter(window_masters.into_iter().map(|(master_id, master_uid)| {
             let graph = &graph;
             let from = &from;
             let to = &to;
@@ -93,12 +121,18 @@ pub async fn handle(cmd: ListEvents) -> Result<Vec<Event>> {
 
 const EVENT_SELECT: &str = "id,iCalUId,subject,body,start,end,originalStartTimeZone,originalEndTimeZone,location,isAllDay,isCancelled,recurrence,attendees,organizer,reminderMinutesBeforeStart,isReminderOn,showAs,sensitivity,lastModifiedDateTime,onlineMeeting,originalStart,responseStatus,type";
 
-async fn discover_window_event_ids(
+#[derive(Debug, PartialEq, Eq)]
+struct WindowDiscovery {
+    event_ids: Vec<String>,
+    master_ids: HashSet<String>,
+}
+
+async fn discover_window_events(
     graph: &GraphClient,
     calendar_id: &str,
     from: &str,
     to: &str,
-) -> Result<Vec<String>> {
+) -> Result<WindowDiscovery> {
     let path = format!(
         "/me/calendars/{calendar_id}/calendarView?startDateTime={from}&endDateTime={to}&$select=id,type,seriesMasterId&$top=999"
     );
@@ -106,22 +140,31 @@ async fn discover_window_event_ids(
         .get_paged(&path)
         .await
         .context("Failed to discover events in calendar window")?;
-    collect_window_event_ids(rows)
+    collect_window_events(rows)
 }
 
-fn collect_window_event_ids(rows: Vec<CalendarViewRow>) -> Result<Vec<String>> {
+fn collect_window_events(rows: Vec<CalendarViewRow>) -> Result<WindowDiscovery> {
     let mut ids = Vec::new();
     let mut seen = HashSet::new();
+    let mut master_ids = HashSet::new();
 
     for row in rows {
         let id = match row.event_type.as_str() {
-            "singleInstance" | "seriesMaster" => row.id,
-            "occurrence" | "exception" => row.series_master_id.with_context(|| {
-                format!(
-                    "Calendar view {} {} is missing seriesMasterId",
-                    row.event_type, row.id
-                )
-            })?,
+            "singleInstance" => row.id,
+            "seriesMaster" => {
+                master_ids.insert(row.id.clone());
+                row.id
+            }
+            "occurrence" | "exception" => {
+                let master_id = row.series_master_id.with_context(|| {
+                    format!(
+                        "Calendar view {} {} is missing seriesMasterId",
+                        row.event_type, row.id
+                    )
+                })?;
+                master_ids.insert(master_id.clone());
+                master_id
+            }
             event_type => bail!("Unknown calendar view event type `{event_type}`"),
         };
 
@@ -130,7 +173,49 @@ fn collect_window_event_ids(rows: Vec<CalendarViewRow>) -> Result<Vec<String>> {
         }
     }
 
+    Ok(WindowDiscovery {
+        event_ids: ids,
+        master_ids,
+    })
+}
+
+async fn discover_series_master_ids(graph: &GraphClient, calendar_id: &str) -> Result<Vec<String>> {
+    let path = format!(
+        "/me/calendars/{calendar_id}/events?$select=id,type&$filter=type%20eq%20%27seriesMaster%27&$top=999"
+    );
+    let rows = graph
+        .get_paged(&path)
+        .await
+        .context("Failed to discover Outlook series masters")?;
+    collect_series_master_ids(rows)
+}
+
+fn collect_series_master_ids(rows: Vec<SeriesMasterIndexRow>) -> Result<Vec<String>> {
+    let mut ids = Vec::new();
+    let mut seen = HashSet::new();
+
+    for row in rows {
+        match row.event_type.as_str() {
+            "seriesMaster" if seen.insert(row.id.clone()) => ids.push(row.id),
+            "seriesMaster" | "singleInstance" | "occurrence" | "exception" => {}
+            event_type => bail!("Unknown event index type `{event_type}`"),
+        }
+    }
+
     Ok(ids)
+}
+
+fn merge_event_ids(window_ids: &[String], master_ids: &[String]) -> Vec<String> {
+    let mut ids = Vec::with_capacity(window_ids.len() + master_ids.len());
+    let mut seen = HashSet::new();
+
+    for id in window_ids.iter().chain(master_ids) {
+        if seen.insert(id.as_str()) {
+            ids.push(id.clone());
+        }
+    }
+
+    ids
 }
 
 async fn fetch_event(graph: &GraphClient, event_id: &str) -> Result<GraphEvent> {
@@ -195,38 +280,98 @@ mod tests {
         }
     }
 
+    fn index_row(id: &str, event_type: &str) -> SeriesMasterIndexRow {
+        SeriesMasterIndexRow {
+            id: id.to_string(),
+            event_type: event_type.to_string(),
+        }
+    }
+
     #[test]
-    fn collects_and_deduplicates_logical_event_ids() {
+    fn master_index_schedules_master_when_window_is_empty() {
+        let window = collect_window_events(Vec::new()).unwrap();
+        let masters = collect_series_master_ids(vec![index_row("master", "seriesMaster")]).unwrap();
+
+        assert_eq!(merge_event_ids(&window.event_ids, &masters), vec!["master"]);
+    }
+
+    #[test]
+    fn master_referenced_by_multiple_occurrences_is_fetched_once() {
         let rows = vec![
-            row("single", "singleInstance", None),
-            row("master-row", "seriesMaster", None),
             row("occurrence-1", "occurrence", Some("recurring")),
             row("occurrence-2", "occurrence", Some("recurring")),
             row("exception", "exception", Some("recurring")),
-            row("single", "singleInstance", None),
         ];
 
-        let ids = collect_window_event_ids(rows).unwrap();
+        let window = collect_window_events(rows).unwrap();
 
-        assert_eq!(ids, vec!["single", "master-row", "recurring"]);
+        assert_eq!(window.event_ids, vec!["recurring"]);
+    }
+
+    #[test]
+    fn master_present_in_both_sources_is_fetched_once() {
+        let window = collect_window_events(vec![row("master", "seriesMaster", None)]).unwrap();
+        let masters = collect_series_master_ids(vec![index_row("master", "seriesMaster")]).unwrap();
+
+        assert_eq!(merge_event_ids(&window.event_ids, &masters), vec!["master"]);
+    }
+
+    #[test]
+    fn standalone_index_rows_are_not_scheduled() {
+        let window = collect_window_events(Vec::new()).unwrap();
+        let masters =
+            collect_series_master_ids(vec![index_row("single", "singleInstance")]).unwrap();
+
+        assert!(merge_event_ids(&window.event_ids, &masters).is_empty());
+    }
+
+    #[test]
+    fn only_window_masters_are_selected_for_exception_fetching() {
+        let window = collect_window_events(vec![
+            row("single", "singleInstance", None),
+            row("occurrence", "occurrence", Some("window-master")),
+        ])
+        .unwrap();
+        let masters = collect_series_master_ids(vec![
+            index_row("window-master", "seriesMaster"),
+            index_row("historical-master", "seriesMaster"),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            window.master_ids,
+            HashSet::from(["window-master".to_string()])
+        );
+        assert_eq!(
+            merge_event_ids(&window.event_ids, &masters),
+            vec!["single", "window-master", "historical-master"]
+        );
     }
 
     #[test]
     fn rejects_recurring_instance_without_master_id() {
-        let error =
-            collect_window_event_ids(vec![row("occurrence", "occurrence", None)]).unwrap_err();
+        for event_type in ["occurrence", "exception"] {
+            let error = collect_window_events(vec![row("instance", event_type, None)]).unwrap_err();
 
-        assert!(error.to_string().contains("missing seriesMasterId"));
+            assert!(error.to_string().contains("missing seriesMasterId"));
+        }
     }
 
     #[test]
     fn rejects_unknown_event_type() {
-        let error = collect_window_event_ids(vec![row("event", "futureType", None)]).unwrap_err();
+        let error = collect_window_events(vec![row("event", "futureType", None)]).unwrap_err();
 
         assert_eq!(
             error.to_string(),
             "Unknown calendar view event type `futureType`"
         );
+    }
+
+    #[test]
+    fn rejects_unknown_master_index_type() {
+        let error = collect_series_master_ids(vec![index_row("event", "futureType")]).unwrap_err();
+
+        assert_eq!(error.to_string(), "Unknown event index type `futureType`");
     }
 
     #[test]

--- a/caldir-provider-outlook/src/commands/list_events.rs
+++ b/caldir-provider-outlook/src/commands/list_events.rs
@@ -91,7 +91,7 @@ pub async fn handle(cmd: ListEvents) -> Result<Vec<Event>> {
     Ok(all_events)
 }
 
-const EVENT_SELECT: &str = "id,iCalUId,subject,body,start,end,originalStartTimeZone,originalEndTimeZone,location,isAllDay,isCancelled,recurrence,attendees,organizer,reminderMinutesBeforeStart,showAs,sensitivity,lastModifiedDateTime,onlineMeeting,originalStart,responseStatus,type";
+const EVENT_SELECT: &str = "id,iCalUId,subject,body,start,end,originalStartTimeZone,originalEndTimeZone,location,isAllDay,isCancelled,recurrence,attendees,organizer,reminderMinutesBeforeStart,isReminderOn,showAs,sensitivity,lastModifiedDateTime,onlineMeeting,originalStart,responseStatus,type";
 
 async fn discover_window_event_ids(
     graph: &GraphClient,
@@ -227,5 +227,10 @@ mod tests {
             error.to_string(),
             "Unknown calendar view event type `futureType`"
         );
+    }
+
+    #[test]
+    fn event_projection_includes_reminder_state() {
+        assert!(EVENT_SELECT.split(',').any(|field| field == "isReminderOn"));
     }
 }

--- a/caldir-provider-outlook/src/commands/list_events.rs
+++ b/caldir-provider-outlook/src/commands/list_events.rs
@@ -1,15 +1,16 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use caldir_core::Event;
 use caldir_core::provider::ProviderStorage;
 use caldir_core::rpc::ListEvents;
 use chrono::{DateTime, Utc};
+use futures::stream::{self, StreamExt, TryStreamExt};
 
 use crate::app_config::AppConfigStore;
 use crate::constants::PROVIDER_NAME;
 use crate::graph_api::client::GraphClient;
-use crate::graph_api::types::{GraphEvent, GraphResponse};
+use crate::graph_api::types::{CalendarViewRow, GraphEvent};
 use crate::outlook_event::from_outlook::from_outlook;
 use crate::remote_config::OutlookRemoteConfig;
 use crate::session::SessionStore;
@@ -26,75 +27,60 @@ pub async fn handle(cmd: ListEvents) -> Result<Vec<Event>> {
         .await?;
     let graph = GraphClient::new(session.access_token());
 
-    // `/events` returns single events and recurring series masters (with
-    // their RRULE) but NOT exceptions to those series — Microsoft Graph
-    // surfaces exceptions only via `/instances` or `/calendarView`. We
-    // intentionally avoid `/calendarView`'s blanket expansion (which would
-    // turn one weekly meeting into ~50 indistinguishable rows) and instead
-    // call `/instances` once per master, picking out only `type=exception`.
-    // Date filtering on `/events` is intentionally omitted: OData's
-    // `start/dateTime` filter only sees a series master's first occurrence,
-    // so a long-running meeting started years ago would be excluded even if
-    // it has occurrences in our window.
-    let path = format!(
-        "/me/calendars/{}/events?$top=100&$select=id,iCalUId,subject,body,start,end,originalStartTimeZone,originalEndTimeZone,location,isAllDay,isCancelled,recurrence,attendees,organizer,reminderMinutesBeforeStart,showAs,sensitivity,lastModifiedDateTime,onlineMeeting,originalStart,responseStatus,type",
-        config.outlook_calendar_id
-    );
-
-    let mut all_events = Vec::new();
-    // Map outlook event id → master's iCalUId, used to rewrite each
-    // exception's iCalUId so masters and their overrides share the same UID
-    // locally (RFC 5545 — Graph mints unique iCalUIds per exception, which
-    // would otherwise break the (uid, recurrence_id) sync key).
-    let mut master_ids: HashMap<String, String> = HashMap::new();
-    let mut next_link: Option<String> = None;
-    let mut first = true;
-
-    loop {
-        let response = if first {
-            first = false;
-            graph.get(&path).await?
-        } else if let Some(ref url) = next_link {
-            graph.get_url(url).await?
-        } else {
-            break;
-        };
-
-        let page: GraphResponse<GraphEvent> = response
-            .json()
-            .await
-            .context("Failed to parse events response")?;
-
-        for graph_event in page.value {
-            let outlook_id = graph_event.id.clone();
-            let master_uid = graph_event.i_cal_uid.clone();
-            let is_master =
-                graph_event.event_type == "seriesMaster" || graph_event.recurrence.is_some();
-
-            match from_outlook(graph_event, &config.outlook_account) {
-                Ok(event) => {
-                    if is_master {
-                        master_ids.insert(outlook_id, master_uid);
-                    }
-                    all_events.push(event);
-                }
-                Err(_) => continue, // Skip malformed events
-            }
-        }
-
-        next_link = page.next_link;
-        if next_link.is_none() {
-            break;
-        }
-    }
-
     let from = normalize_window_bound(&cmd.from)
         .with_context(|| format!("Invalid `from` timestamp: {}", cmd.from))?;
     let to = normalize_window_bound(&cmd.to)
         .with_context(|| format!("Invalid `to` timestamp: {}", cmd.to))?;
 
-    for (master_id, master_uid) in &master_ids {
-        let exceptions = fetch_exceptions(&graph, master_id, master_uid, &from, &to).await?;
+    // Discover IDs with `/calendarView`, then fetch only those logical events
+    // in full. Recurring exceptions still come from each master's `/instances`.
+    let event_ids =
+        discover_window_event_ids(&graph, &config.outlook_calendar_id, &from, &to).await?;
+
+    let graph_events: Vec<GraphEvent> = stream::iter(event_ids.into_iter().map(|event_id| {
+        let graph = &graph;
+        async move { fetch_event(graph, &event_id).await }
+    }))
+    .buffered(4)
+    .try_collect()
+    .await?;
+
+    let mut all_events = Vec::new();
+    // Outlook event id and iCalUId, used to rewrite each
+    // exception's iCalUId so masters and their overrides share the same UID
+    // locally (RFC 5545 — Graph mints unique iCalUIds per exception, which
+    // would otherwise break the (uid, recurrence_id) sync key).
+    let mut master_ids = Vec::new();
+
+    for graph_event in graph_events {
+        let outlook_id = graph_event.id.clone();
+        let master_uid = graph_event.i_cal_uid.clone();
+        let is_master =
+            graph_event.event_type == "seriesMaster" || graph_event.recurrence.is_some();
+
+        match from_outlook(graph_event, &config.outlook_account) {
+            Ok(event) => {
+                if is_master {
+                    master_ids.push((outlook_id, master_uid));
+                }
+                all_events.push(event);
+            }
+            Err(_) => continue, // Skip malformed events
+        }
+    }
+
+    let exception_sets: Vec<Vec<GraphEvent>> =
+        stream::iter(master_ids.into_iter().map(|(master_id, master_uid)| {
+            let graph = &graph;
+            let from = &from;
+            let to = &to;
+            async move { fetch_exceptions(graph, &master_id, &master_uid, from, to).await }
+        }))
+        .buffered(4)
+        .try_collect()
+        .await?;
+
+    for exceptions in exception_sets {
         for exception in exceptions {
             if let Ok(event) = from_outlook(exception, &config.outlook_account) {
                 all_events.push(event);
@@ -103,6 +89,58 @@ pub async fn handle(cmd: ListEvents) -> Result<Vec<Event>> {
     }
 
     Ok(all_events)
+}
+
+const EVENT_SELECT: &str = "id,iCalUId,subject,body,start,end,originalStartTimeZone,originalEndTimeZone,location,isAllDay,isCancelled,recurrence,attendees,organizer,reminderMinutesBeforeStart,showAs,sensitivity,lastModifiedDateTime,onlineMeeting,originalStart,responseStatus,type";
+
+async fn discover_window_event_ids(
+    graph: &GraphClient,
+    calendar_id: &str,
+    from: &str,
+    to: &str,
+) -> Result<Vec<String>> {
+    let path = format!(
+        "/me/calendars/{calendar_id}/calendarView?startDateTime={from}&endDateTime={to}&$select=id,type,seriesMasterId&$top=999"
+    );
+    let rows = graph
+        .get_paged(&path)
+        .await
+        .context("Failed to discover events in calendar window")?;
+    collect_window_event_ids(rows)
+}
+
+fn collect_window_event_ids(rows: Vec<CalendarViewRow>) -> Result<Vec<String>> {
+    let mut ids = Vec::new();
+    let mut seen = HashSet::new();
+
+    for row in rows {
+        let id = match row.event_type.as_str() {
+            "singleInstance" | "seriesMaster" => row.id,
+            "occurrence" | "exception" => row.series_master_id.with_context(|| {
+                format!(
+                    "Calendar view {} {} is missing seriesMasterId",
+                    row.event_type, row.id
+                )
+            })?,
+            event_type => bail!("Unknown calendar view event type `{event_type}`"),
+        };
+
+        if seen.insert(id.clone()) {
+            ids.push(id);
+        }
+    }
+
+    Ok(ids)
+}
+
+async fn fetch_event(graph: &GraphClient, event_id: &str) -> Result<GraphEvent> {
+    let path = format!("/me/events/{event_id}?$select={EVENT_SELECT}");
+    graph
+        .get(&path)
+        .await?
+        .json()
+        .await
+        .with_context(|| format!("Failed to parse event {event_id}"))
 }
 
 /// Reformat an RFC3339 timestamp as `YYYY-MM-DDTHH:MM:SSZ` for embedding in
@@ -124,42 +162,70 @@ async fn fetch_exceptions(
     to: &str,
 ) -> Result<Vec<GraphEvent>> {
     let path = format!(
-        "/me/events/{}/instances?$top=100&startDateTime={}&endDateTime={}&$select=id,iCalUId,subject,body,start,end,originalStartTimeZone,originalEndTimeZone,location,isAllDay,isCancelled,recurrence,attendees,organizer,reminderMinutesBeforeStart,showAs,sensitivity,lastModifiedDateTime,onlineMeeting,originalStart,responseStatus,type",
-        master_id, from, to
+        "/me/events/{master_id}/instances?$top=999&startDateTime={from}&endDateTime={to}&$select={EVENT_SELECT}"
     );
 
-    let mut out = Vec::new();
-    let mut next_link: Option<String> = None;
-    let mut first = true;
+    let instances: Vec<GraphEvent> = graph
+        .get_paged(&path)
+        .await
+        .with_context(|| format!("Failed to fetch instances of master {master_id}"))?;
 
-    loop {
-        let response = if first {
-            first = false;
-            graph.get(&path).await?
-        } else if let Some(ref url) = next_link {
-            graph.get_url(url).await?
-        } else {
-            break;
-        };
-
-        let page: GraphResponse<GraphEvent> = response
-            .json()
-            .await
-            .with_context(|| format!("Failed to parse instances of master {}", master_id))?;
-
-        for mut instance in page.value {
-            if instance.event_type != "exception" {
-                continue;
+    Ok(instances
+        .into_iter()
+        .filter_map(|mut instance| {
+            if instance.event_type == "exception" {
+                instance.i_cal_uid = master_uid.to_string();
+                Some(instance)
+            } else {
+                None
             }
-            instance.i_cal_uid = master_uid.to_string();
-            out.push(instance);
-        }
+        })
+        .collect())
+}
 
-        next_link = page.next_link;
-        if next_link.is_none() {
-            break;
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(id: &str, event_type: &str, series_master_id: Option<&str>) -> CalendarViewRow {
+        CalendarViewRow {
+            id: id.to_string(),
+            event_type: event_type.to_string(),
+            series_master_id: series_master_id.map(str::to_string),
         }
     }
 
-    Ok(out)
+    #[test]
+    fn collects_and_deduplicates_logical_event_ids() {
+        let rows = vec![
+            row("single", "singleInstance", None),
+            row("master-row", "seriesMaster", None),
+            row("occurrence-1", "occurrence", Some("recurring")),
+            row("occurrence-2", "occurrence", Some("recurring")),
+            row("exception", "exception", Some("recurring")),
+            row("single", "singleInstance", None),
+        ];
+
+        let ids = collect_window_event_ids(rows).unwrap();
+
+        assert_eq!(ids, vec!["single", "master-row", "recurring"]);
+    }
+
+    #[test]
+    fn rejects_recurring_instance_without_master_id() {
+        let error =
+            collect_window_event_ids(vec![row("occurrence", "occurrence", None)]).unwrap_err();
+
+        assert!(error.to_string().contains("missing seriesMasterId"));
+    }
+
+    #[test]
+    fn rejects_unknown_event_type() {
+        let error = collect_window_event_ids(vec![row("event", "futureType", None)]).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Unknown calendar view event type `futureType`"
+        );
+    }
 }

--- a/caldir-provider-outlook/src/graph_api/client.rs
+++ b/caldir-provider-outlook/src/graph_api/client.rs
@@ -3,6 +3,9 @@
 use anyhow::{Context, Result};
 use reqwest::Client;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::graph_api::types::GraphResponse;
 
 const GRAPH_BASE_URL: &str = "https://graph.microsoft.com/v1.0";
 
@@ -40,6 +43,32 @@ impl GraphClient {
             .await
             .with_context(|| format!("GET {url}"))?;
         check_status(response).await
+    }
+
+    pub async fn get_paged<T: DeserializeOwned>(&self, path: &str) -> Result<Vec<T>> {
+        let mut values = Vec::new();
+        let mut next_link: Option<String> = None;
+        let mut first = true;
+
+        loop {
+            let response = if first {
+                first = false;
+                self.get(path).await?
+            } else if let Some(ref url) = next_link {
+                self.get_url(url).await?
+            } else {
+                break;
+            };
+
+            let page: GraphResponse<T> = response
+                .json()
+                .await
+                .context("Failed to parse paginated Graph response")?;
+            values.extend(page.value);
+            next_link = page.next_link;
+        }
+
+        Ok(values)
     }
 
     pub async fn post<B: Serialize + ?Sized>(

--- a/caldir-provider-outlook/src/graph_api/types/mod.rs
+++ b/caldir-provider-outlook/src/graph_api/types/mod.rs
@@ -36,6 +36,16 @@ pub struct GraphCalendar {
     pub can_edit: bool,
 }
 
+/// Minimal event row used to discover logical events in a calendar view.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalendarViewRow {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub series_master_id: Option<String>,
+}
+
 /// Graph API event resource.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/caldir-provider-outlook/src/graph_api/types/mod.rs
+++ b/caldir-provider-outlook/src/graph_api/types/mod.rs
@@ -46,6 +46,14 @@ pub struct CalendarViewRow {
     pub series_master_id: Option<String>,
 }
 
+/// Minimal event row used to index recurring series masters.
+#[derive(Debug, Deserialize)]
+pub struct SeriesMasterIndexRow {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub event_type: String,
+}
+
 /// Graph API event resource.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Fixes #55.

`list_events` fetched every event in the calendar (no date filter, full `$select` including `body`) and then hit `/instances` once per series master.

Now `/calendarView` is used as a window-bounded discovery index (IDs only, `$top=999`), and only the discovered singles and series masters are fetched in full, 4 at a time (Graph's per-mailbox concurrency cap).

Expanded occurrences are never materialized as events, and exceptions still come from each master's `/instances`.

Cost now scales with the requested window instead of calendar history.

---

### To test this locally:

Clone this repo, check out the `outlook-timeout-fix` branch , then run:

```bash
cargo build --release -p caldir-provider-outlook
```

Your `caldir` commands will now use the new Outlook provider.
