### PR TITLE
Fix Google provider edge cases in event pushing

### DIFF
--- a/caldir-provider-google/src/commands/create_event.rs
+++ b/caldir-provider-google/src/commands/create_event.rs
@@ -6,6 +6,7 @@ use google_calendar::types::SendUpdates;
 
 use crate::app_config::AppConfigStore;
 use crate::commands::invite::patch_invite_status;
+use crate::commands::update_event::patch_event_without_attendees;
 use crate::constants::{PROVIDER_EVENT_ID_PROPERTY, PROVIDER_NAME};
 use crate::google_event::{FromGoogle, ToGoogle};
 use crate::remote_config::GoogleRemoteConfig;
@@ -45,34 +46,21 @@ pub async fn handle(cmd: CreateEvent) -> Result<Event> {
 
             return Event::from_google(google_event);
         } else {
-            let mut google_event = cmd.event.to_google();
-
-            google_event.id = instance_id.clone();
-
-            // Overrides never carry their own RRULE in Google's model.
-            google_event.recurrence = Vec::new();
-
-            let response = client
-                .events()
-                .update(
-                    calendar_id,
-                    &instance_id,
-                    0,
-                    0,
-                    false,
-                    SendUpdates::All,
-                    false,
-                    &google_event,
+            let google_event = patch_event_without_attendees(
+                session.access_token(),
+                calendar_id,
+                &instance_id,
+                &cmd.event,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to update recurring instance: {}",
+                    cmd.event.summary.as_deref().unwrap_or_default()
                 )
-                .await
-                .with_context(|| {
-                    format!(
-                        "Failed to update recurring instance: {}",
-                        google_event.summary
-                    )
-                })?;
+            })?;
 
-            return Event::from_google(response.body);
+            return Event::from_google(google_event);
         }
     }
 

--- a/caldir-provider-google/src/commands/delete_event.rs
+++ b/caldir-provider-google/src/commands/delete_event.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use caldir_core::provider::ProviderStorage;
 use caldir_core::rpc::DeleteEvent;
 use google_calendar::types::SendUpdates;
+use google_calendar::{ClientError, StatusCode};
 
 use crate::app_config::AppConfigStore;
 use crate::constants::{PROVIDER_EVENT_ID_PROPERTY, PROVIDER_NAME};
@@ -29,11 +30,54 @@ pub async fn handle(cmd: DeleteEvent) -> Result<()> {
         .await?;
     let client = session_store.client(&session, &app_config_store)?;
 
-    client
+    match client
         .events()
         .delete(calendar_id, google_event_id, false, SendUpdates::All)
         .await
-        .context("Failed to delete event")?;
+    {
+        Ok(_) => Ok(()),
+        Err(error) if is_already_deleted_error(&error) => Ok(()),
+        Err(error) => Err(error).context("Failed to delete event"),
+    }
+}
 
-    Ok(())
+fn is_already_deleted_error(error: &ClientError) -> bool {
+    matches!(
+        error,
+        ClientError::HttpError {
+            status: StatusCode::GONE | StatusCode::NOT_FOUND,
+            ..
+        }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use google_calendar::HeaderMap;
+
+    fn http_error(status: StatusCode) -> ClientError {
+        ClientError::HttpError {
+            status,
+            headers: HeaderMap::new(),
+            error: String::new(),
+        }
+    }
+
+    #[test]
+    fn gone_event_is_already_deleted() {
+        assert!(is_already_deleted_error(&http_error(StatusCode::GONE)));
+    }
+
+    #[test]
+    fn missing_event_is_already_deleted() {
+        assert!(is_already_deleted_error(&http_error(StatusCode::NOT_FOUND)));
+    }
+
+    #[test]
+    fn other_http_errors_are_not_already_deleted() {
+        assert!(!is_already_deleted_error(&http_error(
+            StatusCode::FORBIDDEN
+        )));
+    }
 }

--- a/caldir-provider-google/src/commands/update_event.rs
+++ b/caldir-provider-google/src/commands/update_event.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::app_config::AppConfigStore;
 use crate::commands::invite::patch_invite_status;
-use crate::constants::{PROVIDER_EVENT_ID_PROPERTY, PROVIDER_NAME};
+use crate::constants::{PROVIDER_EVENT_ID_PROPERTY, PROVIDER_EVENT_TYPE_PROPERTY, PROVIDER_NAME};
 use crate::google_event::{FromGoogle, ToGoogle};
 use crate::remote_config::GoogleRemoteConfig;
 use crate::session::SessionStore;
@@ -88,6 +88,13 @@ pub(crate) async fn patch_event_without_attendees(
 }
 
 fn patch_body_without_attendees(event: &Event) -> Result<Value> {
+    if event.x_property(PROVIDER_EVENT_TYPE_PROPERTY) == Some("birthday") {
+        return Ok(serde_json::json!({
+            "eventType": "birthday",
+            "summary": event.summary.clone().unwrap_or_default(),
+        }));
+    }
+
     let mut body = serde_json::to_value(event.to_google())?;
 
     if let Value::Object(fields) = &mut body {
@@ -113,7 +120,7 @@ fn patch_body_without_attendees(event: &Event) -> Result<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use caldir_core::{Attendee, EventTime, Recurrence};
+    use caldir_core::{Attendee, EventTime, Recurrence, XProperty};
     use chrono::{NaiveDate, TimeZone, Utc};
 
     #[test]
@@ -134,6 +141,43 @@ mod tests {
             Some("Weekly sync")
         );
         assert!(body.get("recurrence").is_some());
+    }
+
+    #[test]
+    fn birthday_patch_only_updates_summary() {
+        let mut event = Event::new(
+            "Alice's birthday",
+            EventTime::Date(NaiveDate::from_ymd_opt(2026, 7, 10).unwrap()),
+        );
+        event.description = Some("Should not be sent".into());
+        event.location = Some("This should not be sent either".into());
+        event.x_properties = vec![XProperty::new(PROVIDER_EVENT_TYPE_PROPERTY, "birthday")];
+
+        let body = patch_body_without_attendees(&event).unwrap();
+
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "eventType": "birthday",
+                "summary": "Alice's birthday",
+            })
+        );
+    }
+
+    #[test]
+    fn patch_body_includes_description() {
+        let mut event = Event::new(
+            "Planning",
+            EventTime::Date(NaiveDate::from_ymd_opt(2026, 7, 10).unwrap()),
+        );
+        event.description = Some("Bring the roadmap".into());
+
+        let body = patch_body_without_attendees(&event).unwrap();
+
+        assert_eq!(
+            body.get("description").and_then(Value::as_str),
+            Some("Bring the roadmap")
+        );
     }
 
     #[test]

--- a/caldir-provider-google/src/commands/update_event.rs
+++ b/caldir-provider-google/src/commands/update_event.rs
@@ -11,6 +11,8 @@ use crate::google_event::{FromGoogle, ToGoogle};
 use crate::remote_config::GoogleRemoteConfig;
 use crate::session::SessionStore;
 
+const BIRTHDAY_PATCH_FIELDS: &[&str] = &["summary", "colorId", "reminders"];
+
 pub async fn handle(cmd: UpdateEvent) -> Result<Event> {
     let config = GoogleRemoteConfig::try_from(&cmd.remote)?;
     let account_email = &config.google_account;
@@ -88,16 +90,15 @@ pub(crate) async fn patch_event_without_attendees(
 }
 
 fn patch_body_without_attendees(event: &Event) -> Result<Value> {
-    if event.x_property(PROVIDER_EVENT_TYPE_PROPERTY) == Some("birthday") {
-        return Ok(serde_json::json!({
-            "eventType": "birthday",
-            "summary": event.summary.clone().unwrap_or_default(),
-        }));
-    }
-
     let mut body = serde_json::to_value(event.to_google())?;
 
     if let Value::Object(fields) = &mut body {
+        if event.x_property(PROVIDER_EVENT_TYPE_PROPERTY) == Some("birthday") {
+            fields.retain(|key, _| BIRTHDAY_PATCH_FIELDS.contains(&key.as_str()));
+
+            return Ok(body);
+        }
+
         fields.remove("attendees");
 
         for key in ["start", "end"] {
@@ -120,7 +121,7 @@ fn patch_body_without_attendees(event: &Event) -> Result<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use caldir_core::{Attendee, EventTime, Recurrence, XProperty};
+    use caldir_core::{Attendee, EventTime, Recurrence, Reminder, XProperty};
     use chrono::{NaiveDate, TimeZone, Utc};
 
     #[test]
@@ -144,22 +145,32 @@ mod tests {
     }
 
     #[test]
-    fn birthday_patch_only_updates_summary() {
+    fn birthday_patch_only_updates_supported_fields() {
         let mut event = Event::new(
             "Alice's birthday",
             EventTime::Date(NaiveDate::from_ymd_opt(2026, 7, 10).unwrap()),
         );
         event.description = Some("Should not be sent".into());
         event.location = Some("This should not be sent either".into());
-        event.x_properties = vec![XProperty::new(PROVIDER_EVENT_TYPE_PROPERTY, "birthday")];
+        event.reminders = vec![Reminder {
+            minutes_before_start: 15,
+        }];
+        event.x_properties = vec![
+            XProperty::new(PROVIDER_EVENT_TYPE_PROPERTY, "birthday"),
+            XProperty::new(crate::constants::PROVIDER_COLOR_ID_PROPERTY, "5"),
+        ];
 
         let body = patch_body_without_attendees(&event).unwrap();
 
         assert_eq!(
             body,
             serde_json::json!({
-                "eventType": "birthday",
                 "summary": "Alice's birthday",
+                "colorId": "5",
+                "reminders": {
+                    "overrides": [{"method": "popup", "minutes": 15}],
+                    "useDefault": false,
+                },
             })
         );
     }

--- a/caldir-provider-google/src/commands/update_event.rs
+++ b/caldir-provider-google/src/commands/update_event.rs
@@ -58,7 +58,7 @@ pub async fn handle(cmd: UpdateEvent) -> Result<Event> {
     }
 }
 
-async fn patch_event_without_attendees(
+pub(crate) async fn patch_event_without_attendees(
     access_token: &str,
     calendar_id: &str,
     event_id: &str,

--- a/caldir-provider-google/src/commands/update_event.rs
+++ b/caldir-provider-google/src/commands/update_event.rs
@@ -92,6 +92,19 @@ fn patch_body_without_attendees(event: &Event) -> Result<Value> {
 
     if let Value::Object(fields) = &mut body {
         fields.remove("attendees");
+
+        for key in ["start", "end"] {
+            let Some(Value::Object(time)) = fields.get_mut(key) else {
+                continue;
+            };
+
+            if time.contains_key("dateTime") {
+                time.insert("date".to_string(), Value::Null);
+            } else if time.contains_key("date") {
+                time.insert("dateTime".to_string(), Value::Null);
+                time.insert("timeZone".to_string(), Value::Null);
+            }
+        }
     }
 
     Ok(body)
@@ -101,7 +114,7 @@ fn patch_body_without_attendees(event: &Event) -> Result<Value> {
 mod tests {
     use super::*;
     use caldir_core::{Attendee, EventTime, Recurrence};
-    use chrono::NaiveDate;
+    use chrono::{NaiveDate, TimeZone, Utc};
 
     #[test]
     fn patch_body_omits_attendees() {
@@ -121,5 +134,44 @@ mod tests {
             Some("Weekly sync")
         );
         assert!(body.get("recurrence").is_some());
+    }
+
+    #[test]
+    fn timed_patch_explicitly_clears_all_day_date() {
+        let mut event = Event::new(
+            "Timed event",
+            EventTime::DateTimeUtc(Utc.with_ymd_and_hms(2026, 7, 10, 9, 0, 0).unwrap()),
+        );
+        event.end = Some(EventTime::DateTimeUtc(
+            Utc.with_ymd_and_hms(2026, 7, 10, 10, 0, 0).unwrap(),
+        ));
+
+        let body = patch_body_without_attendees(&event).unwrap();
+
+        for key in ["start", "end"] {
+            let time = body.get(key).and_then(Value::as_object).unwrap();
+            assert!(time.get("dateTime").is_some());
+            assert_eq!(time.get("date"), Some(&Value::Null));
+        }
+    }
+
+    #[test]
+    fn all_day_patch_explicitly_clears_timed_fields() {
+        let mut event = Event::new(
+            "All-day event",
+            EventTime::Date(NaiveDate::from_ymd_opt(2026, 7, 10).unwrap()),
+        );
+        event.end = Some(EventTime::Date(
+            NaiveDate::from_ymd_opt(2026, 7, 11).unwrap(),
+        ));
+
+        let body = patch_body_without_attendees(&event).unwrap();
+
+        for key in ["start", "end"] {
+            let time = body.get(key).and_then(Value::as_object).unwrap();
+            assert!(time.get("date").is_some_and(|date| !date.is_null()));
+            assert_eq!(time.get("dateTime"), Some(&Value::Null));
+            assert_eq!(time.get("timeZone"), Some(&Value::Null));
+        }
     }
 }

--- a/caldir-provider-google/src/constants.rs
+++ b/caldir-provider-google/src/constants.rs
@@ -1,3 +1,4 @@
 pub const PROVIDER_NAME: &str = "google";
 pub const PROVIDER_EVENT_ID_PROPERTY: &str = "X-GOOGLE-EVENT-ID";
 pub const PROVIDER_COLOR_ID_PROPERTY: &str = "X-GOOGLE-COLOR-ID";
+pub const PROVIDER_EVENT_TYPE_PROPERTY: &str = "X-GOOGLE-EVENT-TYPE";

--- a/caldir-provider-google/src/google_event/from_google.rs
+++ b/caldir-provider-google/src/google_event/from_google.rs
@@ -4,7 +4,9 @@ use caldir_core::{
     RecurrenceId, Reminder, Status, Visibility, XProperty,
 };
 
-use crate::constants::{PROVIDER_COLOR_ID_PROPERTY, PROVIDER_EVENT_ID_PROPERTY};
+use crate::constants::{
+    PROVIDER_COLOR_ID_PROPERTY, PROVIDER_EVENT_ID_PROPERTY, PROVIDER_EVENT_TYPE_PROPERTY,
+};
 
 pub trait FromGoogle {
     fn from_google(event: google_calendar::types::Event) -> Result<Self>
@@ -100,6 +102,12 @@ impl FromGoogle for Event {
         }
         if !event.color_id.is_empty() {
             x_properties.push(XProperty::new(PROVIDER_COLOR_ID_PROPERTY, event.color_id));
+        }
+        if !event.event_type.is_empty() && event.event_type != "default" {
+            x_properties.push(XProperty::new(
+                PROVIDER_EVENT_TYPE_PROPERTY,
+                event.event_type,
+            ));
         }
 
         Ok(Event {
@@ -430,6 +438,29 @@ mod tests {
         let event = Event::from_google(minimal_event()).unwrap();
 
         assert_eq!(event.url, None);
+    }
+
+    #[test]
+    fn special_event_type_is_preserved_as_provider_metadata() {
+        let mut ge = minimal_event();
+        ge.event_type = "focusTime".into();
+
+        let event = Event::from_google(ge).unwrap();
+
+        assert_eq!(
+            event.x_property(PROVIDER_EVENT_TYPE_PROPERTY),
+            Some("focusTime")
+        );
+    }
+
+    #[test]
+    fn default_event_type_is_not_written_to_ics() {
+        let mut ge = minimal_event();
+        ge.event_type = "default".into();
+
+        let event = Event::from_google(ge).unwrap();
+
+        assert_eq!(event.x_property(PROVIDER_EVENT_TYPE_PROPERTY), None);
     }
 
     // `useDefault: true` means "inherit the calendar's default reminders". We


### PR DESCRIPTION
Four fixes for the Google provider, adapted from the patch maintained in
[omarchy-google-calendar-clock-refresh](https://github.com/guiestrela/omarchy-google-calendar-clock-refresh) (thanks @guiestrela!):

- **All-day <-> timed switches**: Google PATCH deep-merges `start`/`end`, so the old representation must be cleared with explicit nulls or the update is rejected with "Invalid start time".
- **Recurring instance overrides**: push via PATCH instead of PUT. The full PUT replaced Google's resource with our smaller ICS model, wiping provider-owned instance fields and re-sending the whole attendee list.
- **Deletes**: treat 410/404 as success — an EXDATE on the master can remove the expanded override remotely before our delete diff runs.
- **Birthday events**: round-trip `eventType` as `X-GOOGLE-EVENT-TYPE`; birthday events only accept summary updates, so patch only that.