### PR TITLE
Support explicit no-reminders state for Google

### DIFF
--- a/caldir-provider-google/README.md
+++ b/caldir-provider-google/README.md
@@ -5,8 +5,8 @@
 Recurring events are fetched with `singleEvents=false`, preserving each series
 as a master with an `RRULE` instead of expanding every occurrence.
 
-Only explicit event reminder overrides are stored. Google calendar-level
-default reminders are not copied into individual events.
+Explicit event reminder overrides are stored as `VALARM`s. Google calendar-level
+defaults are represented by a property rather than copied into individual events.
 
 ## Google-specific ICS properties
 
@@ -15,6 +15,13 @@ default reminders are not copied into individual events.
 Google identifies events with its own internal ID, separate from the RFC 5545
 `UID`. The provider stores that ID in `X-GOOGLE-EVENT-ID` when pulling an event
 and uses it for later updates and deletes.
+
+### `X-GOOGLE-DEFAULT-REMINDERS`
+
+`X-GOOGLE-DEFAULT-REMINDERS:TRUE` means the event inherits its Google calendar's
+default reminders. Without `VALARM`s or this marker, the event has no reminders.
+Set the marker to `FALSE` to opt out; the provider removes it after Google
+confirms the no-reminders state.
 
 ### `X-GOOGLE-CONFERENCE`
 

--- a/caldir-provider-google/src/commands/update_event.rs
+++ b/caldir-provider-google/src/commands/update_event.rs
@@ -176,6 +176,28 @@ mod tests {
     }
 
     #[test]
+    fn birthday_with_default_reminders_marker_uses_calendar_defaults() {
+        let mut event = Event::new(
+            "Alice's birthday",
+            EventTime::Date(NaiveDate::from_ymd_opt(2026, 7, 10).unwrap()),
+        );
+        event.x_properties = vec![
+            XProperty::new(GOOGLE_EVENT_TYPE_PROPERTY, "birthday"),
+            XProperty::new(crate::constants::GOOGLE_DEFAULT_REMINDERS_PROPERTY, "TRUE"),
+        ];
+
+        let body = patch_body_without_attendees(&event).unwrap();
+
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "summary": "Alice's birthday",
+                "reminders": {"useDefault": true},
+            })
+        );
+    }
+
+    #[test]
     fn patch_body_includes_description() {
         let mut event = Event::new(
             "Planning",

--- a/caldir-provider-google/src/constants.rs
+++ b/caldir-provider-google/src/constants.rs
@@ -2,3 +2,4 @@ pub const PROVIDER_NAME: &str = "google";
 pub(crate) const GOOGLE_EVENT_ID_PROPERTY: &str = "X-GOOGLE-EVENT-ID";
 pub(crate) const GOOGLE_COLOR_ID_PROPERTY: &str = "X-GOOGLE-COLOR-ID";
 pub(crate) const GOOGLE_EVENT_TYPE_PROPERTY: &str = "X-GOOGLE-EVENT-TYPE";
+pub(crate) const GOOGLE_DEFAULT_REMINDERS_PROPERTY: &str = "X-GOOGLE-DEFAULT-REMINDERS";

--- a/caldir-provider-google/src/google_event/from_google.rs
+++ b/caldir-provider-google/src/google_event/from_google.rs
@@ -5,7 +5,8 @@ use caldir_core::{
 };
 
 use crate::constants::{
-    GOOGLE_COLOR_ID_PROPERTY, GOOGLE_EVENT_ID_PROPERTY, GOOGLE_EVENT_TYPE_PROPERTY,
+    GOOGLE_COLOR_ID_PROPERTY, GOOGLE_DEFAULT_REMINDERS_PROPERTY, GOOGLE_EVENT_ID_PROPERTY,
+    GOOGLE_EVENT_TYPE_PROPERTY,
 };
 
 pub trait FromGoogle {
@@ -34,10 +35,9 @@ impl FromGoogle for Event {
         let recurrence_id = google_dt_to_event_time(event.original_start_time.as_ref())
             .map(RecurrenceId::from_event_time);
 
-        // Note: when `reminders.useDefault: true` and overrides is empty, we
-        // intentionally leave reminders empty here — the local file has no
-        // VALARM, and `to_google` reads "no VALARM" as "inherit Google's
-        // calendar default reminders" on push.
+        // Overrides become VALARMs. The default state is carried separately so
+        // the local file does not pin today's calendar defaults.
+        let use_default_reminders = event.reminders.as_ref().is_some_and(|r| r.use_default);
         let reminders: Vec<Reminder> = if let Some(ref rem) = event.reminders {
             rem.overrides
                 .iter()
@@ -105,6 +105,9 @@ impl FromGoogle for Event {
         }
         if !event.event_type.is_empty() && event.event_type != "default" {
             x_properties.push(XProperty::new(GOOGLE_EVENT_TYPE_PROPERTY, event.event_type));
+        }
+        if use_default_reminders {
+            x_properties.push(XProperty::new(GOOGLE_DEFAULT_REMINDERS_PROPERTY, "TRUE"));
         }
 
         Ok(Event {
@@ -259,6 +262,7 @@ fn google_to_participation_status(google_status: &str) -> Option<ParticipationSt
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::google_event::ToGoogle;
     use google_calendar::types as g;
 
     fn empty_event() -> g::Event {
@@ -460,12 +464,8 @@ mod tests {
         assert_eq!(event.x_property(GOOGLE_EVENT_TYPE_PROPERTY), None);
     }
 
-    // `useDefault: true` means "inherit the calendar's default reminders". We
-    // deliberately don't expand those into explicit VALARMs locally: round-
-    // tripping back via `to_google` would then send them as overrides and
-    // pin the event to today's defaults, even if the calendar default later
-    // changes. The empty-reminders state on disk is what makes the next push
-    // emit `useDefault: true` again.
+    // The marker preserves "inherit the calendar defaults" without expanding
+    // today's defaults into VALARMs and pinning the event to them.
     #[test]
     fn use_default_reminders_produces_empty_reminders() {
         let mut ge = minimal_event();
@@ -477,6 +477,10 @@ mod tests {
         let event = Event::from_google(ge).unwrap();
 
         assert!(event.reminders.is_empty());
+        assert_eq!(
+            event.x_property(GOOGLE_DEFAULT_REMINDERS_PROPERTY),
+            Some("TRUE")
+        );
     }
 
     #[test]
@@ -494,5 +498,55 @@ mod tests {
 
         assert_eq!(event.reminders.len(), 1);
         assert_eq!(event.reminders[0].minutes_before_start, 10);
+        assert_eq!(event.x_property(GOOGLE_DEFAULT_REMINDERS_PROPERTY), None);
+    }
+
+    #[test]
+    fn explicit_no_reminders_produces_no_marker() {
+        let mut ge = minimal_event();
+        ge.reminders = Some(g::Reminders {
+            use_default: false,
+            overrides: vec![],
+        });
+
+        let event = Event::from_google(ge).unwrap();
+
+        assert!(event.reminders.is_empty());
+        assert_eq!(event.x_property(GOOGLE_DEFAULT_REMINDERS_PROPERTY), None);
+    }
+
+    #[test]
+    fn missing_reminders_field_produces_no_marker() {
+        let event = Event::from_google(minimal_event()).unwrap();
+
+        assert!(event.reminders.is_empty());
+        assert_eq!(event.x_property(GOOGLE_DEFAULT_REMINDERS_PROPERTY), None);
+    }
+
+    #[test]
+    fn default_reminders_marker_round_trips() {
+        let mut event = Event::from_google(minimal_event()).unwrap();
+        event
+            .x_properties
+            .push(XProperty::new(GOOGLE_DEFAULT_REMINDERS_PROPERTY, "TRUE"));
+
+        let round_tripped = Event::from_google(event.to_google()).unwrap();
+
+        assert_eq!(
+            round_tripped.x_property(GOOGLE_DEFAULT_REMINDERS_PROPERTY),
+            Some("TRUE")
+        );
+    }
+
+    #[test]
+    fn no_reminders_marker_is_not_added_during_round_trip() {
+        let event = Event::from_google(minimal_event()).unwrap();
+
+        let round_tripped = Event::from_google(event.to_google()).unwrap();
+
+        assert_eq!(
+            round_tripped.x_property(GOOGLE_DEFAULT_REMINDERS_PROPERTY),
+            None
+        );
     }
 }

--- a/caldir-provider-google/src/google_event/to_google.rs
+++ b/caldir-provider-google/src/google_event/to_google.rs
@@ -3,7 +3,9 @@ use caldir_core::{
     Status, Visibility,
 };
 
-use crate::constants::{GOOGLE_COLOR_ID_PROPERTY, GOOGLE_EVENT_ID_PROPERTY};
+use crate::constants::{
+    GOOGLE_COLOR_ID_PROPERTY, GOOGLE_DEFAULT_REMINDERS_PROPERTY, GOOGLE_EVENT_ID_PROPERTY,
+};
 
 pub trait ToGoogle {
     fn to_google(&self) -> google_calendar::types::Event;
@@ -47,19 +49,13 @@ impl ToGoogle for Event {
             })
             .collect();
 
-        // "No VALARM locally" = "inherit Google's calendar defaults"
-        // Sending `None` here would otherwise clear the calendar-level default
-        let reminders = if valid_reminders.is_empty() {
-            Some(google_calendar::types::Reminders {
-                overrides: vec![],
-                use_default: true,
-            })
-        } else {
-            Some(google_calendar::types::Reminders {
-                overrides: valid_reminders,
-                use_default: false,
-            })
-        };
+        // VALARMs always win. Without them: marker means inherit Google's
+        // calendar defaults, otherwise no reminders.
+        let use_default = valid_reminders.is_empty() && uses_default_reminders(self);
+        let reminders = Some(google_calendar::types::Reminders {
+            overrides: valid_reminders,
+            use_default,
+        });
 
         let attendees: Vec<google_calendar::types::EventAttendee> =
             self.attendees.iter().map(attendee_to_google).collect();
@@ -111,6 +107,12 @@ impl ToGoogle for Event {
             ..Default::default()
         }
     }
+}
+
+fn uses_default_reminders(event: &Event) -> bool {
+    event
+        .x_property(GOOGLE_DEFAULT_REMINDERS_PROPERTY)
+        .is_some_and(|value| value.eq_ignore_ascii_case("TRUE"))
 }
 
 fn google_meet_conference_data(
@@ -299,9 +301,8 @@ mod tests {
             "expected 0-minute reminder to be filtered out, got {:?}",
             reminders.overrides
         );
-        // With no surviving overrides, fall back to the calendar default
-        // rather than sending an empty `overrides` array that would clear it.
-        assert!(reminders.use_default);
+        // With no surviving overrides or marker, send no reminders.
+        assert!(!reminders.use_default);
     }
 
     #[test]
@@ -340,18 +341,76 @@ mod tests {
         assert!(!reminders.use_default);
     }
 
-    // Local files without VALARMs must push as `useDefault: true` so that
-    // we don't silently strip Google's calendar-level default reminders on push.
     #[test]
-    fn empty_reminders_sends_use_default_true() {
+    fn no_valarm_and_no_marker_sends_no_reminders() {
         let event = sample_event();
         assert!(event.reminders.is_empty());
 
         let google = event.to_google();
         let reminders = google.reminders.expect("reminders always set");
 
+        assert!(!reminders.use_default);
+        assert!(reminders.overrides.is_empty());
+    }
+
+    #[test]
+    fn default_reminders_marker_sends_use_default_true() {
+        let mut event = sample_event();
+        event.x_properties = vec![XProperty::new(GOOGLE_DEFAULT_REMINDERS_PROPERTY, "TRUE")];
+
+        let reminders = event.to_google().reminders.expect("reminders always set");
+
         assert!(reminders.use_default);
         assert!(reminders.overrides.is_empty());
+    }
+
+    #[test]
+    fn marker_false_sends_no_reminders() {
+        let mut event = sample_event();
+        event.x_properties = vec![XProperty::new(GOOGLE_DEFAULT_REMINDERS_PROPERTY, "FALSE")];
+
+        let reminders = event.to_google().reminders.expect("reminders always set");
+
+        assert!(!reminders.use_default);
+        assert!(reminders.overrides.is_empty());
+    }
+
+    #[test]
+    fn marker_value_is_case_insensitive() {
+        let mut event = sample_event();
+        event.x_properties = vec![XProperty::new(GOOGLE_DEFAULT_REMINDERS_PROPERTY, "true")];
+
+        let reminders = event.to_google().reminders.expect("reminders always set");
+
+        assert!(reminders.use_default);
+    }
+
+    #[test]
+    fn valarms_win_over_default_reminders_marker() {
+        let mut event = sample_event();
+        event.reminders = vec![Reminder {
+            minutes_before_start: 20,
+        }];
+        event.x_properties = vec![XProperty::new(GOOGLE_DEFAULT_REMINDERS_PROPERTY, "TRUE")];
+
+        let reminders = event.to_google().reminders.expect("reminders always set");
+
+        assert!(!reminders.use_default);
+        assert_eq!(reminders.overrides.len(), 1);
+        assert_eq!(reminders.overrides[0].minutes, 20);
+    }
+
+    #[test]
+    fn no_reminders_serialise_with_explicit_use_default_false() {
+        let reminders = google_calendar::types::Reminders {
+            use_default: false,
+            overrides: vec![],
+        };
+
+        assert_eq!(
+            serde_json::to_value(reminders).unwrap(),
+            serde_json::json!({"useDefault": false})
+        );
     }
 
     #[test]


### PR DESCRIPTION
Use `X-GOOGLE-DEFAULT-REMINDERS` to indicate whether to use Google calendar defaults or not.

Events without VALARMs or the marker now explicitly disable reminders.

Fixes https://github.com/t4t5/caldir/issues/63